### PR TITLE
Change _currentSliderPosition in controls.dart

### DIFF
--- a/lib/src/controls.dart
+++ b/lib/src/controls.dart
@@ -258,8 +258,8 @@ class _LiveBottomBarState extends State<LiveBottomBar> {
         if (mounted) {
           setState(() {
             _currentPosition = controller.value.position.inMilliseconds;
-            _currentSliderPosition = controller.value.position.inMilliseconds /
-                controller.value.duration.inMilliseconds;
+            _currentSliderPosition = controller.value.duration.inMilliseconds == 0 ? 
+              0 : controller.value.position.inMilliseconds / controller.value.duration.inMilliseconds;
           });
         }
       },


### PR DESCRIPTION
When i use live youtube player, controller.value.duration.inMilliseconds will be 0 in the first time.
Caused by the above reasons, _currentSliderPosition will be NaN(division by zero) and  report an error.