### PR TITLE
Maybe don't set hardcode cardColor=black is better

### DIFF
--- a/lib/src/controls.dart
+++ b/lib/src/controls.dart
@@ -197,9 +197,7 @@ class _BottomBarState extends State<BottomBar> {
             ),
           ),
           Theme(
-            data: Theme.of(context).copyWith(
-              cardColor: Colors.black,
-            ),
+            data: Theme.of(context),
             child: PopupMenuButton<PlaybackRate>(
               onSelected: controller.setPlaybackRate,
               child: Padding(


### PR DESCRIPTION
Somebody(like me) need another theme PopupMenuButton, not only black background color.

So maybe remove hardcode is better?