### PR TITLE
fix auto play

### DIFF
--- a/lib/src/player.dart
+++ b/lib/src/player.dart
@@ -32,7 +32,9 @@ class __PlayerState extends State<_Player> with WidgetsBindingObserver {
   void didChangeAppLifecycleState(AppLifecycleState state) {
     switch (state) {
       case AppLifecycleState.resumed:
-        widget.controller?.play();
+        if(widget.flags.autoPlay){
+          widget.controller?.play();
+        }
         break;
       case AppLifecycleState.inactive:
       case AppLifecycleState.paused:


### PR DESCRIPTION
When the video player is configured to not auto play, when the app is resumed it starts playing.
To fix that I added a check for the flag.