### PR TITLE
Fix url was call null at function convertUrlToId

### DIFF
--- a/lib/src/youtube_player.dart
+++ b/lib/src/youtube_player.dart
@@ -114,8 +114,8 @@ class YoutubePlayer extends StatefulWidget {
 
   /// Converts fully qualified YouTube Url to video id.
   static String convertUrlToId(String url, [bool trimWhitespaces = true]) {
+    if (url == null || url.isEmpty) return null;
     if (!url.contains("http") && (url.length == 11)) return url;
-    if (url == null || url.length == 0) return null;
     if (trimWhitespaces) url = url.trim();
 
     for (var exp in [


### PR DESCRIPTION
Problem: when url => url.contains("http") throw exception "url was call null"
Resolve: check null after use contains funcion.