### PR TITLE
Allow to toggle controls on full-screen only

### DIFF
--- a/lib/src/player/youtube_player.dart
+++ b/lib/src/player/youtube_player.dart
@@ -360,11 +360,11 @@ class _YoutubePlayerState extends State<YoutubePlayer> {
                 loadingBuilder: (_, child, progress) => progress == null
                     ? child
                     : Container(
-                        color: Colors.black,
-                      ),
+                  color: Colors.black,
+                ),
               ),
             ),
-          if (!controller.flags.hideControls &&
+          if ((!controller.flags.hideControls || (controller.value.isFullScreen && controller.flags.controlsVisibleOnFullScreenOnly)) &&
               controller.value.position > Duration(milliseconds: 100) &&
               !controller.value.isControlsVisible &&
               widget.showVideoProgressIndicator &&
@@ -385,7 +385,7 @@ class _YoutubePlayerState extends State<YoutubePlayer> {
                 ),
               ),
             ),
-          if (!controller.flags.hideControls) ...[
+          if (!controller.flags.hideControls || (controller.value.isFullScreen && controller.flags.controlsVisibleOnFullScreenOnly)) ...[
             TouchShutter(
               disableDragSeek: controller.flags.disableDragSeek,
               timeOut: widget.controlsTimeOut,
@@ -395,30 +395,30 @@ class _YoutubePlayerState extends State<YoutubePlayer> {
               left: 0,
               right: 0,
               child: AnimatedOpacity(
-                opacity: !controller.flags.hideControls &&
-                        controller.value.isControlsVisible
+                opacity: (!controller.flags.hideControls || (controller.value.isFullScreen && controller.flags.controlsVisibleOnFullScreenOnly)) &&
+                    controller.value.isControlsVisible
                     ? 1
                     : 0,
                 duration: Duration(milliseconds: 300),
                 child: controller.flags.isLive
                     ? LiveBottomBar(liveUIColor: widget.liveUIColor)
                     : Padding(
-                        padding: widget.bottomActions == null
-                            ? EdgeInsets.all(0.0)
-                            : widget.actionsPadding,
-                        child: Row(
-                          children: widget.bottomActions ??
-                              [
-                                SizedBox(width: 14.0),
-                                CurrentPosition(),
-                                SizedBox(width: 8.0),
-                                ProgressBar(isExpanded: true),
-                                RemainingDuration(),
-                                PlaybackSpeedButton(),
-                                FullScreenButton(),
-                              ],
-                        ),
-                      ),
+                  padding: widget.bottomActions == null
+                      ? EdgeInsets.all(0.0)
+                      : widget.actionsPadding,
+                  child: Row(
+                    children: widget.bottomActions ??
+                        [
+                          SizedBox(width: 14.0),
+                          CurrentPosition(),
+                          SizedBox(width: 8.0),
+                          ProgressBar(isExpanded: true),
+                          RemainingDuration(),
+//                                PlaybackSpeedButton(),
+                          FullScreenButton(),
+                        ],
+                  ),
+                ),
               ),
             ),
             Positioned(
@@ -426,8 +426,8 @@ class _YoutubePlayerState extends State<YoutubePlayer> {
               left: 0,
               right: 0,
               child: AnimatedOpacity(
-                opacity: !controller.flags.hideControls &&
-                        controller.value.isControlsVisible
+                opacity: (!controller.flags.hideControls || (controller.value.isFullScreen && controller.flags.controlsVisibleOnFullScreenOnly)) &&
+                    controller.value.isControlsVisible
                     ? 1
                     : 0,
                 duration: Duration(milliseconds: 300),
@@ -440,7 +440,7 @@ class _YoutubePlayerState extends State<YoutubePlayer> {
               ),
             ),
           ],
-          if (!controller.flags.hideControls)
+          if (!controller.flags.hideControls || (controller.value.isFullScreen && controller.flags.controlsVisibleOnFullScreenOnly))
             Center(
               child: PlayPauseButton(),
             ),

--- a/lib/src/utils/youtube_player_flags.dart
+++ b/lib/src/utils/youtube_player_flags.dart
@@ -14,6 +14,11 @@ class YoutubePlayerFlags {
   /// Default is false.
   final bool controlsVisibleAtStart;
 
+  /// I set to true, shows the controls at full screen only . To be used only if the "hideControls" flag is set to true
+  ///
+  /// Default if false
+  final bool controlsVisibleOnFullScreenOnly;
+
   /// Define whether to auto play the video after initialization or not.
   ///
   /// Default is true.
@@ -77,6 +82,8 @@ class YoutubePlayerFlags {
     this.enableCaption = true,
     this.captionLanguage = 'en',
     this.loop = false,
+    this.controlsVisibleOnFullScreenOnly = false
+
   });
 
   /// Copies new values assigned to the [YoutubePlayerFlags].


### PR DESCRIPTION
1- Added a new Flag inside the file */utils/youtube_player_flags.dart  I’ve added a new flag named  `controlsVisibleOnFullScreenOnly`

2 - Inside the file */player/youtube_player.dart I replaced !controller.flags.hideControls
by `(!controller.flags.hideControls || (controller.value.isFullScreen && controller.flags.controlsVisibleOnFullScreenOnly)) ` everywhere .

This is because by default if the flag `hideControls `is set to True, the full-screen video won’t show any control, even to go back to card view.
We had a use case where we only want to show controls on full-screen, because we had our customized play/pause button for lists