### PR TITLE
added support for passing an optional navigatorKey to YoutubePlayer

### DIFF
--- a/lib/src/player/fullscreen_youtube_player.dart
+++ b/lib/src/player/fullscreen_youtube_player.dart
@@ -15,6 +15,7 @@ import '../widgets/widgets.dart';
 Future<void> showFullScreenYoutubePlayer({
   @required BuildContext context,
   @required YoutubePlayerController controller,
+  GlobalKey<NavigatorState> navigatorKey,
   EdgeInsetsGeometry actionsPadding,
   List<Widget> topActions,
   List<Widget> bottomActions,
@@ -25,25 +26,27 @@ Future<void> showFullScreenYoutubePlayer({
   void Function(YoutubeMetaData) onEnded,
   ProgressBarColors progressColors,
   String thumbnailUrl,
-}) async =>
-    await Navigator.push(
-      context,
-      _YoutubePageRoute(
-        builder: (context) => _FullScreenYoutubePlayer(
-          controller: controller,
-          actionsPadding: actionsPadding,
-          topActions: topActions,
-          bottomActions: bottomActions,
-          bufferIndicator: bufferIndicator,
-          controlsTimeOut: controlsTimeOut,
-          liveUIColor: liveUIColor,
-          onReady: onReady,
-          onEnded: onEnded,
-          progressColors: progressColors,
-          thumbnailUrl: thumbnailUrl,
-        ),
-      ),
-    );
+}) async {
+  final route = _YoutubePageRoute(
+    builder: (context) => _FullScreenYoutubePlayer(
+      controller: controller,
+      actionsPadding: actionsPadding,
+      topActions: topActions,
+      bottomActions: bottomActions,
+      bufferIndicator: bufferIndicator,
+      controlsTimeOut: controlsTimeOut,
+      liveUIColor: liveUIColor,
+      onReady: onReady,
+      onEnded: onEnded,
+      progressColors: progressColors,
+      thumbnailUrl: thumbnailUrl,
+    ),
+  );
+
+  return await navigatorKey != null
+      ? navigatorKey.currentState.push(route)
+      : Navigator.push(context, route);
+}
 
 class _FullScreenYoutubePlayer extends StatefulWidget {
   /// {@macro youtube_player_flutter.controller}

--- a/lib/src/player/raw_youtube_player.dart
+++ b/lib/src/player/raw_youtube_player.dart
@@ -226,7 +226,13 @@ class _RawYoutubePlayerState extends State<RawYoutubePlayer>
             },
           );
         },
-        onPageFinished: (_) {
+        onPageFinished: (_) async {
+          // wait up to 5 seconds for javascript if neccessary
+          for (var i = 0; i < 20; i++) {
+            if (_isPlayerReady) break;
+            await Future.delayed(Duration(milliseconds: 250));
+          }
+
           if (_isPlayerReady) {
             controller.updateValue(
               controller.value.copyWith(isReady: true),

--- a/lib/src/player/youtube_player.dart
+++ b/lib/src/player/youtube_player.dart
@@ -46,6 +46,9 @@ class YoutubePlayer extends StatefulWidget {
   /// Sets [Key] as an identification to underlying web view associated to the player.
   final Key key;
 
+  /// Optional [navigatorKey], If no key is provided the default Navigator will be used.
+  final GlobalKey<NavigatorState> navigatorKey;
+
   /// A [YoutubePlayerController] to control the player.
   final YoutubePlayerController controller;
 
@@ -137,6 +140,7 @@ class YoutubePlayer extends StatefulWidget {
   /// Creates [YoutubePlayer] widget.
   const YoutubePlayer({
     this.key,
+    this.navigatorKey,
     @required this.controller,
     this.width,
     this.aspectRatio = 16 / 9,
@@ -228,7 +232,9 @@ class _YoutubePlayerState extends State<YoutubePlayer> {
         ),
       );
       if (controller.value.isFullScreen) {
-        Navigator.pop(context);
+        widget.navigatorKey != null
+            ? widget.navigatorKey.currentState.pop(context)
+            : Navigator.pop(context);
       } else {
         controller.pause();
         var _cachedPosition = controller.value.position;
@@ -239,6 +245,7 @@ class _YoutubePlayerState extends State<YoutubePlayer> {
         await showFullScreenYoutubePlayer(
           context: context,
           controller: controller,
+          navigatorKey: widget.navigatorKey,
           actionsPadding: widget.actionsPadding,
           bottomActions: widget.bottomActions,
           bufferIndicator: widget.bufferIndicator,


### PR DESCRIPTION
This solves issue the issue where YoutubePlayer is used somewhere above the Navigator. 

Fixes: https://github.com/sarbagyastha/youtube_player_flutter/issues/150

