### PR TITLE
Fix usage of progress color

### DIFF
--- a/lib/src/player/youtube_player.dart
+++ b/lib/src/player/youtube_player.dart
@@ -376,11 +376,7 @@ class _YoutubePlayerState extends State<YoutubePlayer> {
               child: IgnorePointer(
                 ignoring: true,
                 child: ProgressBar(
-                  colors: ProgressBarColors(
-                    handleColor: Colors.transparent,
-                    bufferedColor: Colors.white,
-                    backgroundColor: Colors.black,
-                  ),
+                  colors: widget.progressColors,
                 ),
               ),
             ),
@@ -411,7 +407,7 @@ class _YoutubePlayerState extends State<YoutubePlayer> {
                                 SizedBox(width: 14.0),
                                 CurrentPosition(),
                                 SizedBox(width: 8.0),
-                                ProgressBar(isExpanded: true),
+                                ProgressBar(isExpanded: true, colors: widget.progressColors,),
                                 RemainingDuration(),
                                 PlaybackSpeedButton(),
                                 FullScreenButton(),


### PR DESCRIPTION
When progress colors were being passed to a youtubeplayer the player ignored them. Now the progress bar colors are properly used.

Fixes issue  #186 
