### PR TITLE
Timing and Sizing Issue

### DIFF
--- a/lib/src/player/raw_youtube_player.dart
+++ b/lib/src/player/raw_youtube_player.dart
@@ -35,6 +35,7 @@ class _RawYoutubePlayerState extends State<RawYoutubePlayer>
   YoutubePlayerController controller;
   PlayerState _cachedPlayerState;
   bool _isPlayerReady = false;
+  bool _onLoadStopCalled = false;
 
   @override
   void initState() {
@@ -94,7 +95,14 @@ class _RawYoutubePlayerState extends State<RawYoutubePlayer>
           webController
             ..addJavaScriptHandler(
               handlerName: 'Ready',
-              callback: (_) => _isPlayerReady = true,
+              callback: (_) {
+                _isPlayerReady = true;
+                if (_onLoadStopCalled) {
+                  controller.updateValue(
+                    controller.value.copyWith(isReady: true),
+                  );
+                }
+              },
             )
             ..addJavaScriptHandler(
               handlerName: 'StateChange',
@@ -206,6 +214,7 @@ class _RawYoutubePlayerState extends State<RawYoutubePlayer>
             );
         },
         onLoadStop: (_, __) {
+          _onLoadStopCalled = true;
           if (_isPlayerReady) {
             controller.updateValue(
               controller.value.copyWith(isReady: true),
@@ -315,12 +324,12 @@ class _RawYoutubePlayerState extends State<RawYoutubePlayer>
                 player.cueVideoById(id, startAt, endAt);
                 return '';
             }
-            
+
             function loadPlaylist(playlist, index, startAt) {
                 player.loadPlaylist(playlist, 'playlist', index, startAt);
                 return '';
             }
-            
+
             function cuePlaylist(playlist, index, startAt) {
                 player.cuePlaylist(playlist, 'playlist', index, startAt);
                 return '';
@@ -355,7 +364,7 @@ class _RawYoutubePlayerState extends State<RawYoutubePlayer>
                 player.setPlaybackRate(rate);
                 return '';
             }
-            
+
             function setTopMargin(margin) {
                 document.getElementById("player").style.marginTop = margin;
                 return '';

--- a/lib/src/player/youtube_player.dart
+++ b/lib/src/player/youtube_player.dart
@@ -289,6 +289,7 @@ class _YoutubePlayerState extends State<YoutubePlayer> {
   }
 
   Widget _buildPlayer({Widget errorWidget}) {
+    final EdgeInsets padding = MediaQuery.of(context).padding;
     return AspectRatio(
       aspectRatio: _aspectRatio,
       child: Stack(
@@ -297,7 +298,7 @@ class _YoutubePlayerState extends State<YoutubePlayer> {
         children: [
           Transform.scale(
             scale: controller.value.isFullScreen
-                ? (1 / _aspectRatio * MediaQuery.of(context).size.width) /
+                ? (1 / _aspectRatio * (MediaQuery.of(context).size.width - padding.right - padding.left - padding.bottom)) /
                     MediaQuery.of(context).size.height
                 : 1,
             child: RawYoutubePlayer(


### PR DESCRIPTION
Loading timing issue:
Sometimes the video never loads if onLoadStop is called before the Ready callback. Change it so the order doesn't matter.

Sizing issue:
Video in fullscreen on iPhone X/11 is too large, cutting off some of the video and overlays. Not sure what the exact fix should be, but this change seems to get it pretty close.
