### PR TITLE
adding support for ending a video at any second

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 7.0.0+6
+* **(Improvements)** Added support for `endAt` in load and cue methods as well as `startAt` and `endAt` in video initialization.
+* **(Fixed)** Sticky video watermarks in iOS. Fixes[#208](https://github.com/sarbagyastha/youtube_player_flutter/issues/208)
+* **(Fixed)** Timing and Sizing Issue [#249](https://github.com/sarbagyastha/youtube_player_flutter/pull/249)
+
 ## 7.0.0+5
 * Revert padding on fullscreen.
 

--- a/lib/src/player/raw_youtube_player.dart
+++ b/lib/src/player/raw_youtube_player.dart
@@ -318,31 +318,13 @@ class _RawYoutubePlayerState extends State<RawYoutubePlayer>
                 return '';
             }
 
-            function loadById(id, startAt, endAt) {
-                var loadParams = {
-                  videoId: id,
-                  startSeconds: startAt
-                };
-
-                if (endAt) {
-                  loadParams.endSeconds = endAt;
-                }
-
-                player.loadVideoById(loadParams);
+            function loadById(loadSettings) {
+                player.loadVideoById(loadSettings);
                 return '';
             }
 
-            function cueById(id, startAt, endAt) {
-                var cueParams = {
-                  videoId: id,
-                  startSeconds: startAt
-                };
-
-                if (endAt) {
-                  cueParams.endSeconds = endAt;
-                }
-
-                player.cueVideoById(cueParams);
+            function cueById(cueSettings) {
+                player.cueVideoById(cueSettings);
                 return '';
             }
 

--- a/lib/src/player/raw_youtube_player.dart
+++ b/lib/src/player/raw_youtube_player.dart
@@ -269,7 +269,9 @@ class _RawYoutubePlayerState extends State<RawYoutubePlayer>
                         'modestbranding': 1,
                         'cc_load_policy': ${boolean(value: controller.flags.enableCaption)},
                         'cc_lang_pref': '${controller.flags.captionLanguage}',
-                        'autoplay': ${boolean(value: controller.flags.autoPlay)}
+                        'autoplay': ${boolean(value: controller.flags.autoPlay)},
+                        'start': ${controller.flags.startAt},
+                        'end': ${controller.flags.endAt}
                     },
                     events: {
                         onReady: function(event) { window.flutter_inappwebview.callHandler('Ready'); },
@@ -317,12 +319,30 @@ class _RawYoutubePlayerState extends State<RawYoutubePlayer>
             }
 
             function loadById(id, startAt, endAt) {
-                player.loadVideoById(id, startAt, endAt);
+                var loadParams = {
+                  videoId: id,
+                  startSeconds: startAt
+                };
+
+                if (endAt) {
+                  loadParams.endSeconds = endAt;
+                }
+
+                player.loadVideoById(loadParams);
                 return '';
             }
 
             function cueById(id, startAt, endAt) {
-                player.cueVideoById(id, startAt, endAt);
+                var cueParams = {
+                  videoId: id,
+                  startSeconds: startAt
+                };
+
+                if (endAt) {
+                  cueParams.endSeconds = endAt;
+                }
+
+                player.cueVideoById(cueParams);
                 return '';
             }
 

--- a/lib/src/player/youtube_player.dart
+++ b/lib/src/player/youtube_player.dart
@@ -304,7 +304,7 @@ class _YoutubePlayerState extends State<YoutubePlayer> {
               key: widget.key,
               onEnded: (YoutubeMetaData metaData) {
                 if (controller.flags.loop) {
-                  controller.load(controller.metadata.videoId);
+                  controller.load(controller.metadata.videoId, startAt: controller.flags.startAt, endAt: controller.flags.endAt);
                 }
                 if (widget.onEnded != null) {
                   widget.onEnded(metaData);

--- a/lib/src/utils/youtube_player_controller.dart
+++ b/lib/src/utils/youtube_player_controller.dart
@@ -188,21 +188,29 @@ class YoutubePlayerController extends ValueNotifier<YoutubePlayerValue> {
 
   /// Loads the video as per the [videoId] provided.
   void load(String videoId, {int startAt = 0, int endAt = 0}) {
+    var loadParams = 'videoId:"$videoId",startSeconds:$startAt';
+    if (endAt > startAt) {
+      loadParams += ',endSeconds:$endAt';
+    }
     _updateValues(videoId);
     if (value.errorCode == 1) {
       pause();
     } else {
-      _callMethod('loadById("$videoId",$startAt,$endAt)');
+      _callMethod('loadById({$loadParams})');
     }
   }
 
   /// Cues the video as per the [videoId] provided.
   void cue(String videoId, {int startAt = 0, int endAt = 0}) {
+    var cueParams = 'videoId:"$videoId",startSeconds:$startAt';
+    if (endAt > startAt) {
+      cueParams += ',endSeconds:$endAt';
+    }
     _updateValues(videoId);
     if (value.errorCode == 1) {
       pause();
     } else {
-      _callMethod('cueById("$videoId",$startAt,$endAt)');
+      _callMethod('cueById({$cueParams})');
     }
   }
 

--- a/lib/src/utils/youtube_player_controller.dart
+++ b/lib/src/utils/youtube_player_controller.dart
@@ -187,9 +187,9 @@ class YoutubePlayerController extends ValueNotifier<YoutubePlayerValue> {
   void pause() => _callMethod('pause()');
 
   /// Loads the video as per the [videoId] provided.
-  void load(String videoId, {int startAt = 0, int endAt = 0}) {
+  void load(String videoId, {int startAt = 0, int endAt}) {
     var loadParams = 'videoId:"$videoId",startSeconds:$startAt';
-    if (endAt > startAt) {
+    if (endAt != null && endAt > startAt) {
       loadParams += ',endSeconds:$endAt';
     }
     _updateValues(videoId);
@@ -201,9 +201,9 @@ class YoutubePlayerController extends ValueNotifier<YoutubePlayerValue> {
   }
 
   /// Cues the video as per the [videoId] provided.
-  void cue(String videoId, {int startAt = 0, int endAt = 0}) {
+  void cue(String videoId, {int startAt = 0, int endAt}) {
     var cueParams = 'videoId:"$videoId",startSeconds:$startAt';
-    if (endAt > startAt) {
+    if (endAt != null && endAt > startAt) {
       cueParams += ',endSeconds:$endAt';
     }
     _updateValues(videoId);

--- a/lib/src/utils/youtube_player_controller.dart
+++ b/lib/src/utils/youtube_player_controller.dart
@@ -187,22 +187,22 @@ class YoutubePlayerController extends ValueNotifier<YoutubePlayerValue> {
   void pause() => _callMethod('pause()');
 
   /// Loads the video as per the [videoId] provided.
-  void load(String videoId, {int startAt = 0}) {
+  void load(String videoId, {int startAt = 0, int endAt = 0}) {
     _updateValues(videoId);
     if (value.errorCode == 1) {
       pause();
     } else {
-      _callMethod('loadById("$videoId",$startAt)');
+      _callMethod('loadById("$videoId",$startAt,$endAt)');
     }
   }
 
   /// Cues the video as per the [videoId] provided.
-  void cue(String videoId, {int startAt = 0}) {
+  void cue(String videoId, {int startAt = 0, int endAt = 0}) {
     _updateValues(videoId);
     if (value.errorCode == 1) {
       pause();
     } else {
-      _callMethod('cueById("$videoId",$startAt)');
+      _callMethod('cueById("$videoId",$startAt,$endAt)');
     }
   }
 

--- a/lib/src/utils/youtube_player_flags.dart
+++ b/lib/src/utils/youtube_player_flags.dart
@@ -59,6 +59,16 @@ class YoutubePlayerFlags {
   /// Default is false.
   final bool forceHD;
 
+  /// Specifies the default starting point of the video in seconds
+  ///
+  /// Default is 0.
+  final int startAt;
+
+  /// Specifies the default end point of the video in seconds
+  ///
+  /// Default is 0.
+  final int endAt;
+
   /// Creates [YoutubePlayerFlags].
   const YoutubePlayerFlags({
     this.hideControls = false,
@@ -72,6 +82,8 @@ class YoutubePlayerFlags {
     this.captionLanguage = 'en',
     this.loop = false,
     this.forceHD = false,
+    this.startAt = 0,
+    this.endAt = 0,
   });
 
   /// Copies new values assigned to the [YoutubePlayerFlags].

--- a/lib/src/utils/youtube_player_flags.dart
+++ b/lib/src/utils/youtube_player_flags.dart
@@ -65,8 +65,6 @@ class YoutubePlayerFlags {
   final int startAt;
 
   /// Specifies the default end point of the video in seconds
-  ///
-  /// Default is 0.
   final int endAt;
 
   /// Creates [YoutubePlayerFlags].
@@ -83,7 +81,7 @@ class YoutubePlayerFlags {
     this.loop = false,
     this.forceHD = false,
     this.startAt = 0,
-    this.endAt = 0,
+    this.endAt,
   });
 
   /// Copies new values assigned to the [YoutubePlayerFlags].
@@ -99,6 +97,8 @@ class YoutubePlayerFlags {
     bool enableCaption,
     bool forceHD,
     String captionLanguage,
+    int startAt,
+    int endAt,
   }) {
     return YoutubePlayerFlags(
       autoPlay: autoPlay ?? this.autoPlay,
@@ -111,6 +111,8 @@ class YoutubePlayerFlags {
       loop: loop ?? this.loop,
       mute: mute ?? this.mute,
       forceHD: forceHD ?? this.forceHD,
+      startAt: startAt ?? this.startAt,
+      endAt: endAt ?? this.endAt,
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: youtube_player_flutter
 description: Flutter plugin for playing or streaming inline YouTube videos using the official iFrame player API. This plugin supports both Android and iOS.
-version: 7.0.0+5
+version: 7.0.0+6
 repository: https://github.com/sarbagyastha/youtube_player_flutter
 homepage: https://sarbagyastha.com.np
 


### PR DESCRIPTION
This implementation supports adding an optional ending point (in seconds) for a video to stop, using the:
- [loadVideoById](https://developers.google.com/youtube/iframe_api_reference#Queueing_Functions) API function with an object as a parameter 
- [cueVideoById](https://developers.google.com/youtube/iframe_api_reference#Video_Queueing_Functions) API function with an object as a parameter 

Also supports adding a start and an ending point if loaded by the first time (when the Iframe is created)