### PR TITLE
Fix sticky video watermarks in iOS

### DIFF
--- a/lib/src/player/raw_youtube_player.dart
+++ b/lib/src/player/raw_youtube_player.dart
@@ -230,6 +230,7 @@ class _RawYoutubePlayerState extends State<RawYoutubePlayer>
                 position: fixed;
                 height: 100%;
                 width: 100%;
+                pointer-events: none;
             }
         </style>
         <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no'>


### PR DESCRIPTION
For some reason the IgnorePointer is not totally preventing from clicking the webview content in iOS, so ignoring the pointer-events in the html content is an extra check to avoid this annoying behaviour

Fixing: #208