### PR TITLE
FIX: typo on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,39 +8,42 @@
 [![Top Language](https://img.shields.io/github/languages/top/sarbagyastha/youtube_player_flutter?color=9cf)](https://github.com/sarbagyastha/youtube_player_flutter)
 [![effective dart](https://img.shields.io/badge/style-effective_dart-40c4ff.svg)](https://dart.dev/guides/language/effective-dart)
 
-
 Flutter plugin for playing or streaming YouTube videos inline using the official [**iFrame Player API**](https://developers.google.com/youtube/iframe_api_reference).
 
 Supported Platforms:
-* **Android** 
-* **iOS**
+
+- **Android**
+- **iOS**
 
 ![DEMO](misc/ypf_demo.gif)
 
 ## Salient Features
-* Inline Playback
-* Supports captions
-* No need for API Key
-* Supports custom controls
-* Retrieves video meta data
-* Supports Live Stream videos
-* Supports changing playback rate
-* Support for both Android and iOS
-* Adapts to quality as per the bandwidth
-* Fast Forward and Rewind on horizontal drag
-* Fit Videos to wide screens with pinch gestures
+
+- Inline Playback
+- Supports captions
+- No need for API Key
+- Supports custom controls
+- Retrieves video meta data
+- Supports Live Stream videos
+- Supports changing playback rate
+- Support for both Android and iOS
+- Adapts to quality as per the bandwidth
+- Fast Forward and Rewind on horizontal drag
+- Fit Videos to wide screens with pinch gestures
 
 The plugin uses [flutter_inappwebview](https://pub.dartlang.org/packages/flutter_inappwebview) under-the-hood.
 
-Since *flutter_inappwebview* relies on Flutter's mechanism for embedding Android and iOS views, this plugin might share some known issues tagged with the [platform-views](https://github.com/flutter/flutter/labels/a%3A%20platform-views) label.
+Since _flutter_inappwebview_ relies on Flutter's mechanism for embedding Android and iOS views, this plugin might share some known issues tagged with the [platform-views](https://github.com/flutter/flutter/labels/a%3A%20platform-views) label.
 
 ## Requirements
-* Android: `minSdkVersion 17` and add support for `androidx` (see [AndroidX Migration](https://flutter.dev/docs/development/androidx-migration))
-* iOS: `--ios-language swift`, Xcode version `>= 11`
+
+- Android: `minSdkVersion 17` and add support for `androidx` (see [AndroidX Migration](https://flutter.dev/docs/development/androidx-migration))
+- iOS: `--ios-language swift`, Xcode version `>= 11`
 
 ## Setup
 
 ### iOS
+
 Add these lines to `Info.plist`
 
 ```xml
@@ -51,15 +54,16 @@ Add these lines to `Info.plist`
 For more info, [see here](https://pub.dev/packages/flutter_inappwebview#important-note-for-ios)
 
 ### Android
+
 Set `minSdkVersion` of your `android/app/build.gradle` file to at least 17.
 
 For more info, [see here](https://pub.dev/packages/flutter_inappwebview#important-note-for-android)
 
-*Note:* Although the minimum to be set is 17, the player won't play on device with API < 20. 
+_Note:_ Although the minimum to be set is 17, the player won't play on device with API < 20.
 For API < 20 devices, you might want to forward the video to be played using YouTube app instead, using packages like `url_launcher` or `android_intent`.
 
 #### Using Youtube Player
-         
+
 ```dart
 YoutubePlayerController _controller = YoutubePlayerController(
     initialVideoId: 'iLnmTe5Q2Qw',
@@ -77,13 +81,14 @@ YoutubePlayer(
         playedColor: Colors.amber,
         handleColor: Colors.amberAccent,
     ),
-    onReady () {
+    onReady: () {
         _controller.addListener(listener);
     },
 ),
 ```
 
 #### For FullScreen Support
+
 If fullscreen support is required, wrap your player with `YoutubePlayerBuilder`
 
 ```dart
@@ -103,11 +108,11 @@ YoutubePlayerBuilder(
 ),
 ```
 
-         
 #### Playing live stream videos
+
 Set the isLive property to true in order to change the UI to match Live Video.
 
-![Live UI Demo](misc/live_ui.png) 
+![Live UI Demo](misc/live_ui.png)
 
 ```dart
 YoutubePlayerController _controller = YoutubePlayerController(
@@ -124,15 +129,17 @@ YoutubePlayer(
 ```
 
 ## Want to customize the player?
- With v5.x.x and up, use the `topActions` and `bottomActions` properties to customize the player.
 
- Some of the widgets bundled with the plugin are:
- * FullScreenButton
- * RemainingDuration
- * CurrentPosition
- * PlayPauseButton
- * PlaybackSpeedButton
- * ProgressBar
+With v5.x.x and up, use the `topActions` and `bottomActions` properties to customize the player.
+
+Some of the widgets bundled with the plugin are:
+
+- FullScreenButton
+- RemainingDuration
+- CurrentPosition
+- PlayPauseButton
+- PlaybackSpeedButton
+- ProgressBar
 
 ```dart
 YoutubePlayer(
@@ -145,8 +152,10 @@ YoutubePlayer(
 ),
 ```
 
-## Want to play using Youtube URLs ? 
+## Want to play using Youtube URLs ?
+
 The plugin also provides `convertUrlToId()` method that converts youtube links to its corresponding video ids.
+
 ```dart
 String videoId;
 videoId = YoutubePlayer.convertUrlToId("https://www.youtube.com/watch?v=BBAyRBTfsOU");
@@ -158,19 +167,21 @@ print(videoId); // BBAyRBTfsOU
 [Detailed Example](https://github.com/sarbagyastha/youtube_player_flutter/tree/master/example)
 
 ## Quick Links
-* [YoutubePlayer](https://pub.dev/documentation/youtube_player_flutter/latest/youtube_player_flutter/YoutubePlayer-class.html)
-* [YoutubePlayerController](https://pub.dev/documentation/youtube_player_flutter/latest/youtube_player_flutter/YoutubePlayerController-class.html)
-* [YoutubePlayerFlags](https://pub.dev/documentation/youtube_player_flutter/latest/youtube_player_flutter/YoutubePlayerFlags-class.html)
-* [YoutubePlayerValue](https://pub.dev/documentation/youtube_player_flutter/latest/youtube_player_flutter/YoutubePlayerValue-class.html)
-* [YoutubeMetaData](https://pub.dev/documentation/youtube_player_flutter/latest/youtube_player_flutter/YoutubeMetaData-class.html)
+
+- [YoutubePlayer](https://pub.dev/documentation/youtube_player_flutter/latest/youtube_player_flutter/YoutubePlayer-class.html)
+- [YoutubePlayerController](https://pub.dev/documentation/youtube_player_flutter/latest/youtube_player_flutter/YoutubePlayerController-class.html)
+- [YoutubePlayerFlags](https://pub.dev/documentation/youtube_player_flutter/latest/youtube_player_flutter/YoutubePlayerFlags-class.html)
+- [YoutubePlayerValue](https://pub.dev/documentation/youtube_player_flutter/latest/youtube_player_flutter/YoutubePlayerValue-class.html)
+- [YoutubeMetaData](https://pub.dev/documentation/youtube_player_flutter/latest/youtube_player_flutter/YoutubeMetaData-class.html)
 
 ## Download
+
 Download APKs from above(in badge) and try the plugin.
 APKs are available in Assets of Github release page.
 
-## Limitation 
-Since the plugin is based on platform views. This plugin requires Android API level 20 or greater.
+## Limitation
 
+Since the plugin is based on platform views. This plugin requires Android API level 20 or greater.
 
 ## License
 


### PR DESCRIPTION
Typo on `onReady () {}` to `onReady: () {}`