### PR TITLE
Migrate deprecated Stack attribute 'overflow: Overflow.visible' 

### DIFF
--- a/packages/youtube_player_flutter/lib/src/player/youtube_player.dart
+++ b/packages/youtube_player_flutter/lib/src/player/youtube_player.dart
@@ -293,7 +293,7 @@ class _YoutubePlayerState extends State<YoutubePlayer> {
       aspectRatio: _aspectRatio,
       child: Stack(
         fit: StackFit.expand,
-        overflow: Overflow.visible,
+        clipBehavior: Clip.none,
         children: [
           Transform.scale(
             scale: controller.value.isFullScreen


### PR DESCRIPTION
Fix #361 Migrate deprecated Stack attribute 'overflow: Overflow.visible' to 'clipBehavior: Clip.none'.

Based on the migration guide mentioned in the deprecation MR: https://github.com/flutter/flutter/pull/66305/files

This fix is needed since Flutter 1.23.0-4.0.pre • channel dev 