### PR TITLE
fix type 'int' is not a subtype of type 'double' in type cast

### DIFF
--- a/packages/youtube_player_flutter/lib/src/utils/youtube_meta_data.dart
+++ b/packages/youtube_player_flutter/lib/src/utils/youtube_meta_data.dart
@@ -23,7 +23,7 @@ class YoutubeMetaData {
   /// Creates [YoutubeMetaData] from raw json video data.
   factory YoutubeMetaData.fromRawData(dynamic rawData) {
     final data = rawData as Map<String, dynamic>;
-    final durationInMs = (((data['duration'] ?? 0) as double) * 1000).floor();
+    final durationInMs = ((data['duration'] ?? 0).toDouble() * 1000).floor();
     return YoutubeMetaData(
       videoId: data['videoId'],
       title: data['title'],

--- a/packages/youtube_player_iframe/lib/src/meta_data.dart
+++ b/packages/youtube_player_iframe/lib/src/meta_data.dart
@@ -27,7 +27,7 @@ class YoutubeMetaData {
   /// Creates [YoutubeMetaData] from raw json video data.
   factory YoutubeMetaData.fromRawData(dynamic rawData) {
     final data = rawData as Map<String, dynamic>;
-    final durationInMs = (((data['duration'] ?? 0) as double) * 1000).floor();
+    final durationInMs = ((data['duration'] ?? 0).toDouble() * 1000).floor();
     return YoutubeMetaData(
       videoId: data['videoId'],
       title: data['title'],


### PR DESCRIPTION
Casting using `as` will sometimes result in the error `type 'int' is not a subtype of type 'double' in type cast` when the value of `data['duration']` is an exact integer on my Android device. Calling toDouble instead of casting resolved the issue.