### PR TITLE
Adding service worker instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Supported Platforms:
 For Web, Flutter's [HtmlElementView](https://api.flutter.dev/flutter/widgets/HtmlElementView-class.html).
 For Android & iOS, the package uses [flutter_inappwebview](https://pub.dartlang.org/packages/flutter_inappwebview) under-the-hood.
 
+If your app uses services workers, you may need add additional configuration on the app startup code, in order to ensure that the web view behaviour don't get unstable. To do so, please refer to the [flutter_inappwebview documentation](https://inappwebview.dev/docs/service-worker-api/).
+
 Since *flutter_inappwebview* relies on Flutter's mechanism for embedding Android and iOS views, this plugin might share some known issues tagged with the [platform-views](https://github.com/flutter/flutter/labels/a%3A%20platform-views) label.
 
 ## Requirements


### PR DESCRIPTION
I've recently faced an issue on the app I work on because we use a lot with web views that loads PWA applications.

We noticed that the issues happened because we had the transitive dependency of the `flutter_inappwebview` package, which is a dependency of this plugin.

After further investigation, we discovered that when using service workers, `flutter_inappwebview` requires some additional code setup for the app to work properly.

So to help people that may face this same issue in the future, this PR proposes adding a small section on the README, warning users about this additional configuration.

Thanks! And I hope this can be useful.