### PR TITLE
[youtube_player_iframe] Fixed override initial load on IOS Platform

### DIFF
--- a/packages/youtube_player_iframe/lib/src/players/youtube_player_mobile.dart
+++ b/packages/youtube_player_iframe/lib/src/players/youtube_player_mobile.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 import 'dart:developer';
+import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -56,6 +57,7 @@ class _MobileYoutubePlayerState extends State<RawYoutubePlayer>
   PlayerState? _cachedPlayerState;
   bool _isPlayerReady = false;
   bool _onLoadStopCalled = false;
+  bool _shouldOverrideUrlOnIosInitialLoad = false;
   late YoutubePlayerValue _value;
 
   @override
@@ -137,6 +139,10 @@ class _MobileYoutubePlayerState extends State<RawYoutubePlayer>
         ),
       ),
       shouldOverrideUrlLoading: (_, detail) async {
+        if(Platform.isIOS && !_shouldOverrideUrlOnIosInitialLoad){
+          _shouldOverrideUrlOnIosInitialLoad = true;
+          return NavigationActionPolicy.ALLOW;
+        }
         final uri = detail.request.url;
         if (uri == null) return NavigationActionPolicy.CANCEL;
 

--- a/packages/youtube_player_iframe/lib/src/players/youtube_player_mobile.dart
+++ b/packages/youtube_player_iframe/lib/src/players/youtube_player_mobile.dart
@@ -139,7 +139,7 @@ class _MobileYoutubePlayerState extends State<RawYoutubePlayer>
         ),
       ),
       shouldOverrideUrlLoading: (_, detail) async {
-        if(Platform.isIOS && !_shouldOverrideUrlOnIosInitialLoad){
+        if(!_shouldOverrideUrlOnIosInitialLoad && Platform.isIOS){
           _shouldOverrideUrlOnIosInitialLoad = true;
           return NavigationActionPolicy.ALLOW;
         }


### PR DESCRIPTION
PR contains fix for #525.
I'm thinking about adding additional variable for YoutubePlayerController that will allow user to set if initialLoad should be overide by default on IOS platform or not and by default it will be set to false to maintain same behaviour as before. 
What do you think @sarbagyastha?