### PR TITLE
Replace 'sddefault' with 'default' thumbnail quality

### DIFF
--- a/packages/youtube_player_flutter/lib/src/enums/thumbnail_quality.dart
+++ b/packages/youtube_player_flutter/lib/src/enums/thumbnail_quality.dart
@@ -14,7 +14,7 @@ class ThumbnailQuality {
   static const String high = 'hqdefault';
 
   /// 640*480
-  static const String standard = 'sddefault';
+  static const String standard = 'default';
 
   /// Unscaled thumbnail
   static const String max = 'maxresdefault';


### PR DESCRIPTION
'sddefault' thumbnail image quality is no longer working. Replaced it with 'default' thumbnail quality. 