### PR TITLE
Play youtube live stream from a channel id

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,19 @@ YoutubePlayerControllerProvider( // Provides controller to all the widget below 
 // Access the controller as: `YoutubePlayerControllerProvider.of(context)` or `controller.ytController`.
 ```
 
+#### Using the player
+
+```dart
+YoutubePlayerController _controller = YoutubePlayerController(
+    initialVideoId: 'NpEaa2P7qZI',
+    channelId: 'UCLA_DiR1FfKNvjuUpBHmylQ',
+    params: YoutubePlayerParams(
+        showControls: true,
+        showFullscreenButton: true,
+    ),
+);
+```
+
 ## Want to customize the player?
 The package provides `YoutubeValueBuilder`, which can be used to create any custom controls.
 

--- a/packages/youtube_player_iframe/README.md
+++ b/packages/youtube_player_iframe/README.md
@@ -95,6 +95,19 @@ YoutubePlayerControllerProvider( // Provides controller to all the widget below 
 // Access the controller as: `YoutubePlayerControllerProvider.of(context)` or `controller.ytController`.
 ```
 
+#### Using the player
+
+```dart
+YoutubePlayerController _controller = YoutubePlayerController(
+    initialVideoId: 'NpEaa2P7qZI',
+    channelId: 'UCLA_DiR1FfKNvjuUpBHmylQ',
+    params: YoutubePlayerParams(
+        showControls: true,
+        showFullscreenButton: true,
+    ),
+);
+```
+
 ## Want to customize the player?
 The package provides `YoutubeValueBuilder`, which can be used to create any custom controls.
 

--- a/packages/youtube_player_iframe/lib/src/controller.dart
+++ b/packages/youtube_player_iframe/lib/src/controller.dart
@@ -25,6 +25,7 @@ class YoutubePlayerController {
   /// Creates [YoutubePlayerController].
   YoutubePlayerController({
     required this.initialVideoId,
+    this.channelId,
     this.params = const YoutubePlayerParams(),
   }) {
     invokeJavascript = (_) async {};
@@ -32,6 +33,9 @@ class YoutubePlayerController {
 
   /// The Youtube video id for initial video to be loaded.
   final String initialVideoId;
+
+  /// The optional channel id to display a live stream from a channel.
+  final String? channelId;
 
   /// Defines default parameters for the player.
   final YoutubePlayerParams params;

--- a/packages/youtube_player_iframe/lib/src/helpers/player_fragments.dart
+++ b/packages/youtube_player_iframe/lib/src/helpers/player_fragments.dart
@@ -1,3 +1,5 @@
+import 'dart:developer';
+
 import 'package:youtube_player_iframe/youtube_player_iframe.dart';
 
 ///
@@ -25,12 +27,18 @@ String youtubeIFrameTag(YoutubePlayerController controller) {
     if (controller.params.playlist.isNotEmpty)
       'playlist': '${controller.params.playlist.join(',')}'
   };
+  if (controller.channelId != null) {
+    params['channel'] = controller.channelId as String;
+  }
   final youtubeAuthority = controller.params.privacyEnhanced
       ? 'www.youtube-nocookie.com'
       : 'www.youtube.com';
+  final embedUrl = controller.channelId != null
+      ? 'embed/live_stream'
+      : 'embed/${controller.initialVideoId}';
   final sourceUri = Uri.https(
     youtubeAuthority,
-    'embed/${controller.initialVideoId}',
+    embedUrl,
     params,
   );
   return '<iframe id="player" type="text/html"'


### PR DESCRIPTION
The video id for live streams seems to change quite often, however a channel id is constant. Therefore, here's a practical way to display a youtube live stream providing a `channelId` to the controller.

Note that I didn't want to make any breaking changes so I left `videoId` as required. If `channelId` is provided, the former will simply be ignored. 