### PR TITLE
Have YoutubePlayerController extend Stream

### DIFF
--- a/packages/youtube_player_iframe/lib/src/controller/youtube_player_controller.dart
+++ b/packages/youtube_player_iframe/lib/src/controller/youtube_player_controller.dart
@@ -69,6 +69,10 @@ class YoutubePlayerController implements YoutubePlayerIFrameAPI {
       StreamController.broadcast();
   YoutubePlayerValue _value = YoutubePlayerValue();
 
+  /// A Stream of [YoutubePlayerValue], which allows you to subscribe to changes
+  /// in the controller value.
+  Stream<YoutubePlayerValue> get stream => _valueController.stream;
+
   /// The [YoutubePlayerValue].
   YoutubePlayerValue get value => _value;
 


### PR DESCRIPTION
As the listen override is already implemented, this allows for all the
built in Stream methods to be used on the controller.