### PR TITLE
Add support for https://www.youtube-nocookie.com in origin params

### DIFF
--- a/packages/youtube_player_iframe/assets/player.html
+++ b/packages/youtube_player_iframe/assets/player.html
@@ -43,9 +43,11 @@
       firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
 
       var platform = "<<platform>>";
+      var host = "<<host>>";
       var player;
       function onYouTubeIframeAPIReady() {
         player = new YT.Player("player", {
+          host: host,
           playerVars: <<playerVars>>,
           events: {
             onReady: function (event) {

--- a/packages/youtube_player_iframe/lib/src/controller/youtube_player_controller.dart
+++ b/packages/youtube_player_iframe/lib/src/controller/youtube_player_controller.dart
@@ -234,7 +234,8 @@ class YoutubePlayerController implements YoutubePlayerIFrameAPI {
     await controller.loadHtmlString(
       playerHtml
           .replaceFirst('<<playerVars>>', params.toJson())
-          .replaceFirst('<<platform>>', platform),
+          .replaceFirst('<<platform>>', platform)
+          .replaceFirst('<<host>>', params.origin ?? 'https://www.youtube.com'),
       baseUrl: baseUrl,
     );
   }


### PR DESCRIPTION
Origin youtube-nocookie.com specifies if the video player uses youtube-nocookie.com, then the Watch Later and Share buttons will be automatically hidden.