### PR TITLE
Pass in background color to underlying webview

### DIFF
--- a/packages/youtube_player_iframe/assets/player.html
+++ b/packages/youtube_player_iframe/assets/player.html
@@ -44,11 +44,12 @@
 
       var platform = "<<platform>>";
       var host = "<<host>>";
+      var playerVars = "<<playerVars>>"
       var player;
       function onYouTubeIframeAPIReady() {
         player = new YT.Player("player", {
           host: host,
-          playerVars: <<playerVars>>,
+          playerVars: playerVars,
           events: {
             onReady: function (event) {
               handleFullScreenForMobilePlatform();

--- a/packages/youtube_player_iframe/assets/player.html
+++ b/packages/youtube_player_iframe/assets/player.html
@@ -44,12 +44,11 @@
 
       var platform = "<<platform>>";
       var host = "<<host>>";
-      var playerVars = "<<playerVars>>"
       var player;
       function onYouTubeIframeAPIReady() {
         player = new YT.Player("player", {
           host: host,
-          playerVars: playerVars,
+          playerVars: <<playerVars>>,
           events: {
             onReady: function (event) {
               handleFullScreenForMobilePlatform();

--- a/packages/youtube_player_iframe/lib/src/youtube_player_scaffold.dart
+++ b/packages/youtube_player_iframe/lib/src/youtube_player_scaffold.dart
@@ -80,6 +80,7 @@ class _YoutubePlayerScaffoldState extends State<YoutubePlayerScaffold> {
         controller: widget.controller,
         aspectRatio: widget.aspectRatio,
         gestureRecognizers: widget.gestureRecognizers,
+        backgroundColor: widget.backgroundColor,
       ),
     );
 


### PR DESCRIPTION
### Issues addressed: 

1. `player.html` flags a lint error, to fix it, i declared a variable `var playerVars = "<<playerVars>>"`, and passed it into `onYoutubeIframeAPIReady`. This approach is similar to that of the variables `platform` and `host`. The issue is shown in the screenshot below 
<img width="416" alt="Screenshot 2022-10-05 at 10 57 10 AM" src="https://user-images.githubusercontent.com/65481917/193971519-35c69ede-3738-4950-97f6-6c24ed2a1f22.png">

2. The `backgroundColor` parameter in the `YoutubePlayerScaffold` isn't used/passed in to the `WebView` of the `YoutubePlayer`

<img width="417" alt="Screenshot 2022-10-05 at 11 03 06 AM" src="https://user-images.githubusercontent.com/65481917/193972032-c2455630-066e-4b46-aebb-81c522ca6f18.png">

<img width="400" alt="Screenshot 2022-10-05 at 11 04 47 AM" src="https://user-images.githubusercontent.com/65481917/193972235-4686e4e5-b1bf-4a06-9d38-9cc1878c02ba.png">



@sarbagyastha Do let me know what you think about this
