### PR TITLE
check if stream close before update

### DIFF
--- a/packages/youtube_player_iframe/lib/src/controller/youtube_player_controller.dart
+++ b/packages/youtube_player_iframe/lib/src/controller/youtube_player_controller.dart
@@ -294,6 +294,8 @@ class YoutubePlayerController implements YoutubePlayerIFrameAPI {
     YoutubeError? error,
     YoutubeMetaData? metaData,
   }) {
+    if (_valueController.isClosed) return;
+
     final updatedValue = YoutubePlayerValue(
       fullScreenOption: fullScreenOption ?? value.fullScreenOption,
       playerState: playerState ?? value.playerState,


### PR DESCRIPTION
fix 
Bad state: Cannot add new events after calling close
```
Non-fatal Exception: FlutterError
0  ???                            0x0 _BroadcastStreamController.add (dart:async)
1  ???                            0x0 YoutubePlayerController.update + 306 (youtube_player_controller.dart:306)
2  ???                            0x0 YoutubePlayerEventHandler.onPlaybackQualityChange + 89 (youtube_player_event_handler.dart:89)
3  ???                            0x0 new YoutubePlayerEventHandler.<fn> + 31 (youtube_player_event_handler.dart:31)
4  ???                            0x0 JavascriptChannelRegistry.onJavascriptChannelMessage + 28 (javascript_channel_registry.dart:28)
5  ???                            0x0 WebKitWebViewPlatformController.addJavascriptChannels.<fn>.<fn>.<fn> + 446 (web_kit_webview_widget.dart:446)
6  ???                            0x0 WKScriptMessageHandlerFlutterApiImpl.didReceiveScriptMessage + 404 (web_kit_api_impls.dart:404)
7  ???                            0x0 WKScriptMessageHandlerFlutterApi.setup.<fn> + 1267 (web_kit.pigeon.dart:1267)
8  ???                            0x0 BasicMessageChannel.setMessageHandler.<fn> + 197 (platform_channel.dart:197)
9  ???                            0x0 _DefaultBinaryMessenger.setMessageHandler.<fn> + 387 (binding.dart:387)
```