### PR TITLE
WillPopScope removed

### DIFF
--- a/packages/youtube_player_iframe/lib/src/youtube_player_scaffold.dart
+++ b/packages/youtube_player_iframe/lib/src/youtube_player_scaffold.dart
@@ -169,15 +169,13 @@ class _FullScreenState extends State<_FullScreen> with WidgetsBindingObserver {
 
   @override
   Widget build(BuildContext context) {
-    return WillPopScope(
-      onWillPop: _handleFullScreenBackAction,
-      child: widget.child,
-    );
+    return widget.child;
   }
 
   @override
   void dispose() {
     if (widget.auto) WidgetsBinding.instance.removeObserver(this);
+    _handleFullScreenBackAction();
     super.dispose();
   }
 


### PR DESCRIPTION
WillPopScope disables swipe back gesture, that's why I have removed it. Function inside WillPopScope has been moved into dispose method.