### PR TITLE
Add params to control pointer events

### DIFF
--- a/packages/youtube_player_iframe/assets/player.html
+++ b/packages/youtube_player_iframe/assets/player.html
@@ -11,11 +11,13 @@
         width: 100%;
         height: 100%;
         background-color: black;
+        pointer-events: <<pointerEvents>>;
       }
       html {
         width: 100%;
         height: 100%;
         background-color: black;
+        pointer-events: <<pointerEvents>>;
       }
 
       .embed-container iframe,
@@ -26,6 +28,7 @@
         left: 0;
         width: 100% !important;
         height: 100% !important;
+        pointer-events: <<pointerEvents>>;
       }
     </style>
     <title>Youtube Player</title>

--- a/packages/youtube_player_iframe/lib/src/controller/youtube_player_controller.dart
+++ b/packages/youtube_player_iframe/lib/src/controller/youtube_player_controller.dart
@@ -230,9 +230,11 @@ class YoutubePlayerController implements YoutubePlayerIFrameAPI {
 
     final controller = await _webViewControllerCompleter.future;
     final platform = kIsWeb ? 'web' : defaultTargetPlatform.name.toLowerCase();
+    final pointerEvents = params.enablePointerEvents ? 'auto' : 'none';
 
     await controller.loadHtmlString(
       playerHtml
+          .replaceAll('<<pointerEvents>>', pointerEvents)
           .replaceFirst('<<playerVars>>', params.toJson())
           .replaceFirst('<<platform>>', platform)
           .replaceFirst('<<host>>', params.origin ?? 'https://www.youtube.com'),

--- a/packages/youtube_player_iframe/lib/src/player_params.dart
+++ b/packages/youtube_player_iframe/lib/src/player_params.dart
@@ -34,6 +34,12 @@ class YoutubePlayerParams {
   /// Default is true.
   final bool enableCaption;
 
+  /// Settings the parameter's value to false will disable any gestures to be propagated to the iframe
+  /// by passing 'none' to the `pointer-events` param in `player.html`
+  ///
+  /// Useful especially for iOS where the gesture propagates even with the use of `IgnorePointer` widget
+  final bool enablePointerEvents;
+
   /// This parameter specifies the color that will be used in the player's video progress bar to highlight the amount of the video that the viewer has already seen.
   /// Valid parameter values are red and white, and, by default, the player uses the color red in the video progress bar.
   ///
@@ -129,6 +135,7 @@ class YoutubePlayerParams {
     this.mute = false,
     this.captionLanguage = 'en',
     this.enableCaption = true,
+    this.enablePointerEvents = true,
     this.color = 'white',
     this.showControls = true,
     this.enableKeyboard = kIsWeb,


### PR DESCRIPTION
@sarbagyastha do let me know what you think about this PR

- This is essential because on iOS, even though wrapping the youtube iframe with an `IgnorePointer` widget, the gesture still passes through and registers as a long press, toggling the context menus
- To resolve this, a custom pointer even has to be passed in to the player

https://user-images.githubusercontent.com/65481917/208892749-89353711-a978-47cf-971f-5e85c10c5b44.mov

