### PR TITLE
feature: added extraParams in YoutubePlayerParams class

### DIFF
--- a/packages/youtube_player_iframe/lib/src/player_params.dart
+++ b/packages/youtube_player_iframe/lib/src/player_params.dart
@@ -110,6 +110,9 @@ class YoutubePlayerParams {
   /// The user agent for the player.
   final String? userAgent;
 
+  /// Any parameters that you would like to pass to youtube, eg. widget_referrer.
+  final Map? extraParams;
+
   /// Defines player parameters for the youtube player.
   const YoutubePlayerParams({
     this.mute = false,
@@ -128,6 +131,7 @@ class YoutubePlayerParams {
     this.playsInline = true,
     this.strictRelatedVideos = false,
     this.userAgent,
+    this.extraParams,
   });
 
   /// Creates [Map] representation of [YoutubePlayerParams].
@@ -149,6 +153,7 @@ class YoutubePlayerParams {
       if (origin != null && !kIsWeb) 'origin': origin,
       'playsinline': _boolean(playsInline),
       'rel': _boolean(!strictRelatedVideos),
+      if (extraParams != null) ...extraParams!,
     };
   }
 


### PR DESCRIPTION
Added `extraParams` to support sending multiple parameters to Youtube, eg. widget_referrer="https://yourwebsite.com" for Youtube Analytics to show the referral website