### PR TITLE
fix example in README.md

### DIFF
--- a/packages/youtube_player_flutter/README.md
+++ b/packages/youtube_player_flutter/README.md
@@ -68,13 +68,13 @@ YoutubePlayerController _controller = YoutubePlayerController(
 YoutubePlayer(
     controller: _controller,
     showVideoProgressIndicator: true,
-    videoProgressIndicatorColor: Colors.amber,
-    progressColors: ProgressColors(
-        playedColor: Colors.amber,
-        handleColor: Colors.amberAccent,
+    progressIndicatorColor: Colors.amber,
+    progressColors: const ProgressBarColors(
+      playedColor: Colors.amber,
+      handleColor: Colors.amberAccent,
     ),
-    onReady () {
-        _controller.addListener(listener);
+    onReady: () {
+      _controller.addListener(listener);
     },
 ),
 ```


### PR DESCRIPTION
Fixed example in README.md: typo, outdated parameters.
