### PR TITLE
Migrate youtube_player_flutter_iframe to package:web

### DIFF
--- a/packages/youtube_player_iframe/pubspec.yaml
+++ b/packages/youtube_player_iframe/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-
+  web: ^0.4.0
   flutter_inappwebview: ^5.3.2
   url_launcher: ^6.0.2
 


### PR DESCRIPTION
This migrates the `youtube_player_flutter_iframe` package from `dart:html` to `package:web`, for Wasm compatability.

To migrate the `youtube_player_flutter` package, the [flutter_inappwebview](https://github.com/pichillilorenzo/flutter_inappwebview) package needs to be migrated.