### PR TITLE
fixed onNavigationRequest title click event

### DIFF
--- a/packages/youtube_player_iframe/lib/src/controller/youtube_player_controller.dart
+++ b/packages/youtube_player_iframe/lib/src/controller/youtube_player_controller.dart
@@ -655,6 +655,7 @@ class YoutubePlayerController implements YoutubePlayerIFrameAPI {
         final videoId = params['v'];
         if (videoId != null) loadVideoById(videoId: videoId);
         break;
+      case 'emb_title':
       case 'emb_logo':
       case 'social':
       case 'wl_button':


### PR DESCRIPTION
Fixed an error that didn't go to the YouTube Web when I clicked on the YouTube title on my mobile.