### PR TITLE
fix: handle received messages from javascript

### DIFF
--- a/packages/youtube_player_iframe_web/lib/src/web_youtube_player_iframe_controller.dart
+++ b/packages/youtube_player_iframe_web/lib/src/web_youtube_player_iframe_controller.dart
@@ -206,9 +206,14 @@ class YoutubePlayerIframeWeb extends PlatformWebViewWidget {
         if (channelParams != null) {
           window.onMessage.listen(
             (event) {
-              channelParams.onMessageReceived(
-                JavaScriptMessage(message: event.data.dartify() as String),
-              );
+              final message = switch (event.data.dartify()) {
+                String message => message,
+                Map map => jsonEncode(map),
+                Object? data => throw Exception(
+                    '[$YoutubePlayerIframeWeb] Invalid message type "${data.runtimeType}": $data'),
+              };
+              channelParams
+                  .onMessageReceived(JavaScriptMessage(message: message));
             },
           );
         }


### PR DESCRIPTION
Sometimes Javascript is returning messages that are `Map` instead of `String` and it's throwing an exception.

## Snapshot
![image](https://github.com/user-attachments/assets/d3e20fc9-c5b1-4a7c-be4c-3ceb43c92a36)

