### PR TITLE
Improve YoutubePlayerBuilder for dialogs

### DIFF
--- a/packages/youtube_player_flutter/lib/src/widgets/youtube_player_builder.dart
+++ b/packages/youtube_player_flutter/lib/src/widgets/youtube_player_builder.dart
@@ -7,6 +7,8 @@ import 'package:youtube_player_flutter/youtube_player_flutter.dart';
 /// A wrapper for [YoutubePlayer].
 class YoutubePlayerBuilder extends StatefulWidget {
   /// Builder for [YoutubePlayer] that supports switching between fullscreen and normal mode.
+  /// When popping, if the player is in fullscreen, fullscreen will be toggled,
+  /// otherwise the route will pop.
   const YoutubePlayerBuilder({
     super.key,
     required this.player,
@@ -68,13 +70,11 @@ class _YoutubePlayerBuilderState extends State<YoutubePlayerBuilder>
     final player = Container(
       key: playerKey,
       child: PopScope(
-        canPop: false,
-        onPopInvokedWithResult: (didPop, _) {
+        canPop: !widget.player.controller.value.isFullScreen,
+        onPopInvokedWithResult: (_, __) {
           final controller = widget.player.controller;
           if (controller.value.isFullScreen) {
             widget.player.controller.toggleFullScreenMode();
-          } else {
-            Navigator.pop(context);
           }
         },
         child: widget.player,


### PR DESCRIPTION
PR is targeted to fix issues with `YoutubePlayerBuilder` when paired with a `Dialog`.

- Refactor PopScope to pop if the player is not in fullscreen instead of always false.
- Remove `Navigator.pop` inside `onPopInvokedWithResult` to avoid issues with external navigation. (Example: Pressing dialog barrier, or using an external navigation solution).