### PR TITLE
package:youtube_player_iframe - Making compatible with Flutter 3.22+

### DIFF
--- a/packages/youtube_player_iframe/lib/src/widgets/fullscreen_youtube_player.dart
+++ b/packages/youtube_player_iframe/lib/src/widgets/fullscreen_youtube_player.dart
@@ -63,8 +63,7 @@ class FullscreenYoutubePlayer extends StatefulWidget {
     required String videoId,
     double? startSeconds,
     double? endSeconds,
-    Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers =
-        const <Factory<OneSequenceGestureRecognizer>>{},
+    Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers = const <Factory<OneSequenceGestureRecognizer>>{},
     Color? backgroundColor,
   }) {
     return Navigator.push<double>(
@@ -116,7 +115,7 @@ class _FullscreenYoutubePlayerState extends State<FullscreenYoutubePlayer> {
   Widget build(BuildContext context) {
     return PopScope(
       canPop: false,
-      onPopInvokedWithResult: (didPop, _) {
+      onPopInvoked: (didPop) {
         if (didPop) return;
         _controller.currentTime.then(
           (time) {

--- a/packages/youtube_player_iframe/lib/src/widgets/youtube_player_scaffold.dart
+++ b/packages/youtube_player_iframe/lib/src/widgets/youtube_player_scaffold.dart
@@ -35,8 +35,7 @@ class YoutubePlayerScaffold extends StatefulWidget {
     ],
     this.enableFullScreenOnVerticalDrag = true,
     this.backgroundColor,
-    @Deprecated('Unused parameter. Use `YoutubePlayerParam.userAgent` instead.')
-    this.userAgent,
+    @Deprecated('Unused parameter. Use `YoutubePlayerParam.userAgent` instead.') this.userAgent,
   });
 
   /// Builds the child widget.
@@ -203,7 +202,7 @@ class _FullScreenState extends State<_FullScreen> with WidgetsBindingObserver {
   Widget build(BuildContext context) {
     return PopScope(
       canPop: canPop,
-      onPopInvokedWithResult: _handleFullScreenBackAction,
+      onPopInvoked: _handleFullScreenBackAction,
       child: widget.child,
     );
   }
@@ -227,12 +226,10 @@ class _FullScreenState extends State<_FullScreen> with WidgetsBindingObserver {
   }
 
   SystemUiMode get _uiMode {
-    return widget.fullScreenOption.enabled
-        ? SystemUiMode.immersive
-        : SystemUiMode.edgeToEdge;
+    return widget.fullScreenOption.enabled ? SystemUiMode.immersive : SystemUiMode.edgeToEdge;
   }
 
-  void _handleFullScreenBackAction(bool didPop, _) {
+  void _handleFullScreenBackAction(bool didPop) {
     if (didPop) return;
 
     if (mounted && widget.fullScreenOption.enabled) {

--- a/packages/youtube_player_iframe/pubspec.yaml
+++ b/packages/youtube_player_iframe/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/sarbagyastha/youtube_player_flutter
 homepage: https://github.com/sarbagyastha/youtube_player_flutter/tree/master/packages/youtube_player_iframe
 
 environment:
-  sdk: ^3.3.0
-  flutter: '>=3.19.0'
+  sdk: ^3.4.0
+  flutter: '>=3.22.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
Thanks for this valuable repository

This Pull Request should fix the error described in https://github.com/sarbagyastha/youtube_player_flutter/issues/987

In Flutter 3.22+, the `PopScope` property `onPopInvokedWithResult` was renamed to `onPopInvoked`. As a result, projects using the old name will not be able to compile in the latest Flutter version.

By All-Win Software Team