### PR TITLE
fix: PopScope build errors

### DIFF
--- a/packages/youtube_player_flutter/lib/src/widgets/youtube_player_builder.dart
+++ b/packages/youtube_player_flutter/lib/src/widgets/youtube_player_builder.dart
@@ -75,11 +75,12 @@ class _YoutubePlayerBuilderState extends State<YoutubePlayerBuilder>
       height: orientation == Orientation.landscape ? height : null,
       child: PopScope(
         canPop: !widget.player.controller.value.isFullScreen,
-        onPopInvokedWithResult: (didPop, _) {
+        onPopInvoked: (didPop) {
           if (didPop) return;
+
           final controller = widget.player.controller;
           if (controller.value.isFullScreen) {
-            widget.player.controller.toggleFullScreenMode();
+            controller.toggleFullScreenMode();
           }
         },
         child: widget.player,

--- a/packages/youtube_player_iframe/lib/src/widgets/fullscreen_youtube_player.dart
+++ b/packages/youtube_player_iframe/lib/src/widgets/fullscreen_youtube_player.dart
@@ -116,11 +116,13 @@ class _FullscreenYoutubePlayerState extends State<FullscreenYoutubePlayer> {
   Widget build(BuildContext context) {
     return PopScope(
       canPop: false,
-      onPopInvokedWithResult: (didPop, _) {
+      onPopInvoked: (didPop) {
         if (didPop) return;
         _controller.currentTime.then(
           (time) {
-            if (context.mounted) return Navigator.pop(context, time);
+            if (context.mounted) {
+              Navigator.pop(context, time);
+            }
           },
         );
       },

--- a/packages/youtube_player_iframe/lib/src/widgets/youtube_player_scaffold.dart
+++ b/packages/youtube_player_iframe/lib/src/widgets/youtube_player_scaffold.dart
@@ -203,7 +203,7 @@ class _FullScreenState extends State<_FullScreen> with WidgetsBindingObserver {
   Widget build(BuildContext context) {
     return PopScope(
       canPop: canPop,
-      onPopInvokedWithResult: _handleFullScreenBackAction,
+      onPopInvoked: _handleFullScreenBackAction,
       child: widget.child,
     );
   }
@@ -232,7 +232,7 @@ class _FullScreenState extends State<_FullScreen> with WidgetsBindingObserver {
         : SystemUiMode.edgeToEdge;
   }
 
-  void _handleFullScreenBackAction(bool didPop, _) {
+  void _handleFullScreenBackAction(bool didPop) {
     if (didPop) return;
 
     if (mounted && widget.fullScreenOption.enabled) {


### PR DESCRIPTION
In Flutter 3.22+, the PopScope property onPopInvokedWithResult was renamed to onPopInvoked. As a result, projects using the old name will not be able to compile in the latest Flutter version.