### PR TITLE
chore: use MediaQuery.sizeOf() instead of MediaQuery.of().size to avoid unnecessary rebuilds

### DIFF
--- a/packages/youtube_player_flutter/lib/src/player/youtube_player.dart
+++ b/packages/youtube_player_flutter/lib/src/player/youtube_player.dart
@@ -237,7 +237,7 @@ class _YoutubePlayerState extends State<YoutubePlayer> {
         controller: controller,
         child: Container(
           color: Colors.black,
-          width: widget.width ?? MediaQuery.of(context).size.width,
+          width: widget.width ?? MediaQuery.sizeOf(context).width,
           child: _buildPlayer(
             errorWidget: Container(
               color: Colors.black87,


### PR DESCRIPTION
Use:

```dart
MediaQuery.sizeOf(context)
```

instead of:

```dart
MediaQuery.of(context).size
```

`MediaQuery.sizeOf` was introduced in Flutter 3.10 and only listen for size changes instead of all properties, the minimum Flutter SDK in this project is 3.24 so should be available.

You will probably need to update other parts of the project to use the new `paddingOf` and the others if they are used, I was trying to identify a bug (not related to this project) and found this code, this PR is made quickly and more changes might be needed.

It seems that [YoutubePlayerBuilder](https://github.com/sarbagyastha/youtube_player_flutter/blob/f8e1e79991066bcc70f0a7c93941ca0d54b7370e/packages/youtube_player_flutter/lib/src/widgets/youtube_player_builder.dart#L71) is already using `sizeOf` and `orientationOf`.

Widgets like [TouchShutter](https://github.com/sarbagyastha/youtube_player_flutter/blob/f8e1e79991066bcc70f0a7c93941ca0d54b7370e/packages/youtube_player_flutter/lib/src/widgets/touch_shutter.dart#L133-L136) also could use this change.