### PR TITLE
Bump up flutter_inappwebview version

### DIFF
--- a/packages/youtube_player_flutter/CHANGELOG.md
+++ b/packages/youtube_player_flutter/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 9.1.1
+* Bumps `flutter_inappwebview` to latest version.
+
 ## 9.1.0
 * Updates minimum supported SDK version to Flutter 3.24/Dart 3.5.
 * Updates dependencies.

--- a/packages/youtube_player_flutter/pubspec.yaml
+++ b/packages/youtube_player_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: youtube_player_flutter
 description: Flutter plugin for playing or streaming inline YouTube videos using the official iFrame player API. This plugin supports both Android and iOS.
-version: 9.1.0
+version: 9.1.1
 repository: https://github.com/sarbagyastha/youtube_player_flutter
 homepage: https://github.com/sarbagyastha/youtube_player_flutter/tree/main/packages/youtube_player_flutter
 
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_inappwebview: ^6.1.0+1
+  flutter_inappwebview: ^6.1.1+1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Upgrade flutter_inappwebview to version 6.1.1+1, as all versions below 6.1.1 do not build in Xcode 16. See https://github.com/pichillilorenzo/flutter_inappwebview/pull/2274#issuecomment-2368979811 for more information.