### PR TITLE
fix: use constant javascript channel

### DIFF
--- a/packages/youtube_player_iframe/assets/player.html
+++ b/packages/youtube_player_iframe/assets/player.html
@@ -120,10 +120,10 @@
       function sendPlatformMessage(message) {
         switch(platform) {
            case 'android':
-             <<playerId>>.postMessage(message);
+             youtubePlayerChannel.postMessage(message);
              break;
            case 'ios':
-             <<playerId>>.postMessage(message, '*');
+             youtubePlayerChannel.postMessage(message, '*');
              break;
            case 'web':
              window.parent.postMessage(message, '*');

--- a/packages/youtube_player_iframe/lib/src/controller/youtube_player_controller.dart
+++ b/packages/youtube_player_iframe/lib/src/controller/youtube_player_controller.dart
@@ -58,7 +58,10 @@ class YoutubePlayerController implements YoutubePlayerIFrameAPI {
       ..setJavaScriptMode(JavaScriptMode.unrestricted)
       ..setNavigationDelegate(navigationDelegate)
       ..setUserAgent(params.userAgent)
-      ..addJavaScriptChannel(playerId, onMessageReceived: _eventHandler.call)
+      ..addJavaScriptChannel(
+        javaScriptChannel,
+         onMessageReceived: _eventHandler.call,
+      )
       ..enableZoom(false);
 
     final webViewPlatform = webViewController.platform;
@@ -120,6 +123,8 @@ class YoutubePlayerController implements YoutubePlayerIFrameAPI {
 
   /// The [YoutubePlayerValue].
   YoutubePlayerValue get value => _value;
+
+  static const javaScriptChannel = 'youtubePlayerChannel';
 
   @override
   Future<void> cuePlaylist({
@@ -685,7 +690,7 @@ class YoutubePlayerController implements YoutubePlayerIFrameAPI {
   /// Disposes the resources created by [YoutubePlayerController].
   Future<void> close() async {
     await stopVideo();
-    await webViewController.removeJavaScriptChannel('youtube-$hashCode');
+    await webViewController.removeJavaScriptChannel(javaScriptChannel);
     await _eventHandler.videoStateController.close();
     await _valueController.close();
   }


### PR DESCRIPTION
In the method `sendPlatformChannel`, used channel is `playerId`. When the player id contains special characters as "-", it will not send the message to the subscribed channel. 

Fixed by using constant channel.