### PR TITLE
[youtube_player_iframe] fix(PlayerState): incorrect current state of the player.

### DIFF
--- a/packages/youtube_player_iframe/lib/src/controller/youtube_player_controller.dart
+++ b/packages/youtube_player_iframe/lib/src/controller/youtube_player_controller.dart
@@ -571,8 +571,10 @@ class YoutubePlayerController implements YoutubePlayerIFrameAPI {
   Future<PlayerState> get playerState async {
     final stateCode = await _runWithResult('getPlayerState');
 
+    final newStateCode = num.tryParse(stateCode)?.toInt();
+
     return PlayerState.values.firstWhere(
-      (state) => state.code.toString() == stateCode,
+      (state) => state.code == newStateCode,
       orElse: () => PlayerState.unknown,
     );
   }


### PR DESCRIPTION
While developing my app, I found that I can't pause the video when using the `youtube_player_iframe` package

After debugging, I found that `getPlayerState` returns the string `"1.0"`. But in the `PlayerState` enum, you define the code value as int type, so this function always returns `PlayerState.unknown`. Please check the debug screenshot below, thank you 

![image](https://github.com/user-attachments/assets/794119de-ddcc-4970-8ea3-105bbb0a0b46)