### PR TITLE
Issue1045 - Wrapped duration widgets' Text widgets in a stack and added transparent Texts representing largest possible time string - DC

### DIFF
--- a/packages/youtube_player_flutter/lib/src/widgets/duration_widgets.dart
+++ b/packages/youtube_player_flutter/lib/src/widgets/duration_widgets.dart
@@ -52,14 +52,26 @@ class _CurrentPositionState extends State<CurrentPosition> {
 
   @override
   Widget build(BuildContext context) {
-    return Text(
-      durationFormatter(
-        _controller.value.position.inMilliseconds,
-      ),
-      style: const TextStyle(
-        color: Colors.white,
-        fontSize: 12.0,
-      ),
+    return Stack(
+      children: [
+        Text(
+          "${_controller.value.position.inHours != 0 ? '00:' : ''}00:00",
+          key: const Key('hidden-current-position-text'),
+          style: const TextStyle(
+            color: Colors.transparent,
+            fontSize: 12.0,
+          ),
+        ),
+        Text(
+          durationFormatter(
+            _controller.value.position.inMilliseconds,
+          ),
+          style: const TextStyle(
+            color: Colors.white,
+            fontSize: 12.0,
+          ),
+        ),
+      ],
     );
   }
 }
@@ -109,15 +121,27 @@ class _RemainingDurationState extends State<RemainingDuration> {
 
   @override
   Widget build(BuildContext context) {
-    return Text(
-      "- ${durationFormatter(
-        (_controller.metadata.duration.inMilliseconds) -
-            (_controller.value.position.inMilliseconds),
-      )}",
-      style: const TextStyle(
-        color: Colors.white,
-        fontSize: 12.0,
-      ),
+    return Stack(
+      children: [
+        Text(
+          "- ${_controller.value.position.inHours != 0 ? '00:' : ''}00:00",
+          key: const Key('hidden-remaining-duration-text'),
+          style: const TextStyle(
+            color: Colors.transparent,
+            fontSize: 12.0,
+          ),
+        ),
+        Text(
+          "- ${durationFormatter(
+            (_controller.metadata.duration.inMilliseconds) -
+                (_controller.value.position.inMilliseconds),
+          )}",
+          style: const TextStyle(
+            color: Colors.white,
+            fontSize: 12.0,
+          ),
+        ),
+      ],
     );
   }
 }

--- a/packages/youtube_player_flutter/test/src/widgets/duration_widgets_test.dart
+++ b/packages/youtube_player_flutter/test/src/widgets/duration_widgets_test.dart
@@ -1,0 +1,149 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:youtube_player_flutter/youtube_player_flutter.dart';
+
+import '../../youtube_player_flutter_test.dart';
+
+main() {
+  group('CurrentPosition', () {
+    testWidgets(
+      'includes text with Colors.transparent color and "00:00" when duration is < 1hour',
+      (widgetTester) async {
+        final controller = createController();
+        controller.value =
+            YoutubePlayerValue(position: Duration(hours: 0, minutes: 1));
+
+        await widgetTester.pumpWidget(
+          MaterialApp(
+            home: CurrentPosition(
+              controller: controller,
+            ),
+          ),
+        );
+
+        await widgetTester.pumpAndSettle();
+        final hiddenCurrentPositionText = widgetTester.widget<Text>(
+            find.byKey(const Key('hidden-current-position-text')));
+        expect(hiddenCurrentPositionText.data, '00:00');
+        expect(hiddenCurrentPositionText.style?.color, Colors.transparent);
+      },
+    );
+
+    testWidgets(
+      'includes text with Colors.transparent color and "00:00:00" when duration is == 1hour',
+      (widgetTester) async {
+        final controller = createController();
+        controller.value =
+            YoutubePlayerValue(position: Duration(hours: 1, minutes: 0));
+
+        await widgetTester.pumpWidget(
+          MaterialApp(
+            home: CurrentPosition(
+              controller: controller,
+            ),
+          ),
+        );
+
+        await widgetTester.pumpAndSettle();
+        final hiddenCurrentPositionText = widgetTester.widget<Text>(
+            find.byKey(const Key('hidden-current-position-text')));
+        expect(hiddenCurrentPositionText.data, '00:00:00');
+        expect(hiddenCurrentPositionText.style?.color, Colors.transparent);
+      },
+    );
+
+    testWidgets(
+      'includes text with Colors.transparent color and "00:00:00" when duration is > 1hour',
+      (widgetTester) async {
+        final controller = createController();
+        controller.value =
+            YoutubePlayerValue(position: Duration(hours: 1, minutes: 0));
+
+        await widgetTester.pumpWidget(
+          MaterialApp(
+            home: CurrentPosition(
+              controller: controller,
+            ),
+          ),
+        );
+
+        await widgetTester.pumpAndSettle();
+        final hiddenCurrentPositionText = widgetTester.widget<Text>(
+            find.byKey(const Key('hidden-current-position-text')));
+        expect(hiddenCurrentPositionText.data, '00:00:00');
+        expect(hiddenCurrentPositionText.style?.color, Colors.transparent);
+      },
+    );
+  });
+
+  group('RemainingDuration', () {
+    testWidgets(
+      'includes text with Colors.transparent color and "- 00:00" when duration is < 1hour',
+      (widgetTester) async {
+        final controller = createController();
+        controller.value =
+            YoutubePlayerValue(position: Duration(hours: 0, minutes: 1));
+
+        await widgetTester.pumpWidget(
+          MaterialApp(
+            home: RemainingDuration(
+              controller: controller,
+            ),
+          ),
+        );
+
+        await widgetTester.pumpAndSettle();
+        final hiddenCurrentPositionText = widgetTester.widget<Text>(
+            find.byKey(const Key('hidden-remaining-duration-text')));
+        expect(hiddenCurrentPositionText.data, '- 00:00');
+        expect(hiddenCurrentPositionText.style?.color, Colors.transparent);
+      },
+    );
+
+    testWidgets(
+      'includes text with Colors.transparent color and "- 00:00:00" when duration is == 1hour',
+      (widgetTester) async {
+        final controller = createController();
+        controller.value =
+            YoutubePlayerValue(position: Duration(hours: 1, minutes: 0));
+
+        await widgetTester.pumpWidget(
+          MaterialApp(
+            home: RemainingDuration(
+              controller: controller,
+            ),
+          ),
+        );
+
+        await widgetTester.pumpAndSettle();
+        final hiddenCurrentPositionText = widgetTester.widget<Text>(
+            find.byKey(const Key('hidden-remaining-duration-text')));
+        expect(hiddenCurrentPositionText.data, '- 00:00:00');
+        expect(hiddenCurrentPositionText.style?.color, Colors.transparent);
+      },
+    );
+
+    testWidgets(
+      'includes text with Colors.transparent color and "- 00:00:00" when duration is > 1hour',
+      (widgetTester) async {
+        final controller = createController();
+        controller.value =
+            YoutubePlayerValue(position: Duration(hours: 1, minutes: 0));
+
+        await widgetTester.pumpWidget(
+          MaterialApp(
+            home: RemainingDuration(
+              controller: controller,
+            ),
+          ),
+        );
+
+        await widgetTester.pumpAndSettle();
+        final hiddenCurrentPositionText = widgetTester.widget<Text>(
+            find.byKey(const Key('hidden-remaining-duration-text')));
+        expect(hiddenCurrentPositionText.data, '- 00:00:00');
+        expect(hiddenCurrentPositionText.style?.color, Colors.transparent);
+      },
+    );
+  });
+}


### PR DESCRIPTION
This would close #1045 

It is worth noting that this will have some merge conflicts with #1044, should that PR be merged.
If #1044 does end up being merged, we would want to `_CurrentPositionState`'s and `_RemainingDurationState`'s build methods to look like

```dart
@override
  Widget build(BuildContext context) {
    return Stack(
      children: [
        Text(
          "${_controller.value.position.inHours != 0 ? '00:' : ''}00:00",
          key: const Key('hidden-current-position-text'),
          style: const TextStyle(
            color: Colors.transparent,
            fontSize: 12.0,
            height: 1.0,
          ),
        ),
        Text(
          durationFormatter(
            _controller.value.position.inMilliseconds,
          ),
          style: const TextStyle(
            color: Colors.white,
            fontSize: 12.0,
            height: 1.0,
          ),
        ),
      ],
    );
  }
```

and

```dart
@override
  Widget build(BuildContext context) {
    return Stack(
      children: [
        Text(
          "- ${_controller.value.position.inHours != 0 ? '00:' : ''}00:00",
          key: const Key('hidden-remaining-duration-text'),
          style: const TextStyle(
            color: Colors.transparent,
            fontSize: 12.0,
            height: 1.0,
          ),
        ),
        Text(
          "- ${durationFormatter(
            (_controller.metadata.duration.inMilliseconds) -
                (_controller.value.position.inMilliseconds),
          )}",
          style: const TextStyle(
            color: Colors.white,
            fontSize: 12.0,
            height: 1.0,
          ),
        ),
      ],
    );
  }
```
, respectively.