### PR TITLE
convertUrlToId is fixed

### DIFF
--- a/packages/youtube_player_flutter/lib/src/player/youtube_player.dart
+++ b/packages/youtube_player_flutter/lib/src/player/youtube_player.dart
@@ -164,7 +164,9 @@ class YoutubePlayer extends StatefulWidget {
           r"^https:\/\/(?:www\.|m\.)?youtube\.com\/shorts\/([_\-a-zA-Z0-9]{11}).*$"),
       RegExp(
           r"^https:\/\/(?:www\.|m\.)?youtube(?:-nocookie)?\.com\/embed\/([_\-a-zA-Z0-9]{11}).*$"),
-      RegExp(r"^https:\/\/youtu\.be\/([_\-a-zA-Z0-9]{11}).*$")
+      RegExp(r"^https:\/\/youtu\.be\/([_\-a-zA-Z0-9]{11}).*$"),
+      RegExp(
+        r"^https:\/\/(?:www\.)?youtube\.com\/live\/([_\-a-zA-Z0-9]{11})(?:\?.*)?$"),
     ]) {
       Match? match = exp.firstMatch(url);
       if (match != null && match.groupCount >= 1) return match.group(1);


### PR DESCRIPTION
The `convertUrlToId` function is designed to extract the video ID from a valid YouTube Live URL. It ensures proper handling of URLs with optional query parameters and supports both www.youtube.com and standard youtube.com domains. The function uses a precise regular expression to identify and capture the 11-character video ID, enabling seamless integration with applications that rely on parsing YouTube Live links.