### PR TITLE
Fix: Sanitize key to Prevent YouTube Player Event Issues

### DIFF
--- a/packages/youtube_player_iframe/lib/src/controller/youtube_player_controller.dart
+++ b/packages/youtube_player_iframe/lib/src/controller/youtube_player_controller.dart
@@ -78,7 +78,10 @@ class YoutubePlayerController implements YoutubePlayerIFrameAPI {
     double? startSeconds,
     double? endSeconds,
   }) {
-    final controller = YoutubePlayerController(params: params, key: videoId);
+    final controller = YoutubePlayerController(
+      params: params,
+      key: videoId.replaceAll(RegExp(r'[^a-zA-Z0-9_]'), ''),
+    );
 
     if (autoPlay) {
       controller.loadVideoById(


### PR DESCRIPTION
**Issue**
The videoId was passed into the key parameter of YouTubePlayerController, which was then used as the playerId.
If the videoId contained dashes (-), they were interpreted as subtraction operators in JavaScript.
This caused event calls to break, preventing videos to play.

**Fix**
Sanitized the key before passing it to JavaScript to ensure it is treated as a string.