### PR TITLE
feat: added setDebugLogSettings to enable/disable annoying debug log

### DIFF
--- a/packages/youtube_player_flutter/lib/src/utils/youtube_player_controller.dart
+++ b/packages/youtube_player_flutter/lib/src/utils/youtube_player_controller.dart
@@ -313,6 +313,12 @@ class YoutubePlayerController extends ValueNotifier<YoutubePlayerValue> {
         ),
       );
 
+  void setDebugLogSettings({
+    required bool value,
+  }) {
+    PlatformInAppWebViewController.debugLoggingSettings.enabled = value;
+  }
+
   @override
   void dispose() {
     value.webViewController?.dispose();


### PR DESCRIPTION
#1037 
Sometimes during development, the plugin's debug log makes me feel extremely uncomfortable. It prints out continuously on the console, sometimes consuming a lot of laptop resources. Adding this function allows you to turn this log on and off.