### PR TITLE
fix: isMuted return true or false not number 1 or 0

### DIFF
--- a/packages/youtube_player_iframe/lib/src/controller/youtube_player_controller.dart
+++ b/packages/youtube_player_iframe/lib/src/controller/youtube_player_controller.dart
@@ -500,7 +500,7 @@ class YoutubePlayerController implements YoutubePlayerIFrameAPI {
   @override
   Future<bool> get isMuted async {
     final isMuted = await _runWithResult('isMuted');
-    return isMuted == '1';
+    return bool.tryParse(isMuted, caseSensitive: false) ?? false;
   }
 
   @override


### PR DESCRIPTION
[isMuted](https://developers.google.com/youtube/iframe_api_reference#changing-the-player-volume) return ```true``` or ```false``` not 1 or 0

fix #482