### PR TITLE
Add hideYoutubeOverlay flag to hide native YouTube overlay

### DIFF
--- a/packages/youtube_player_flutter/lib/src/player/raw_youtube_player.dart
+++ b/packages/youtube_player_flutter/lib/src/player/raw_youtube_player.dart
@@ -241,6 +241,30 @@ class _RawYoutubePlayerState extends State<RawYoutubePlayer>
                 width: 100%;
                 pointer-events: none;
             }
+            ${controller!.flags.hideYoutubeOverlay ? '''
+            /* Hide YouTube overlay elements */
+            .ytp-title,
+            .ytp-chrome-top,
+            .ytp-show-cards-title,
+            .ytp-title-text,
+            .ytp-title-link,
+            .ytp-title-expanded-overlay,
+            .ytp-gradient-top,
+            .ytp-videowall-still,
+            .ytp-ce-element,
+            .ytp-cards-teaser,
+            .iv-branding,
+            .ytp-pause-overlay {
+                display: none !important;
+                visibility: hidden !important;
+                opacity: 0 !important;
+            }
+            
+            /* Hide the top gradient overlay */
+            .ytp-gradient-top {
+                background: none !important;
+            }
+            ''' : ''}
         </style>
         <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no'>
     </head>
@@ -274,7 +298,31 @@ class _RawYoutubePlayerState extends State<RawYoutubePlayer>
                         'end': ${controller!.flags.endAt}
                     },
                     events: {
-                        onReady: function(event) { window.flutter_inappwebview.callHandler('Ready'); },
+                        onReady: function(event) { 
+                            window.flutter_inappwebview.callHandler('Ready');
+                            ${controller!.flags.hideYoutubeOverlay ? '''
+                            // Additional JavaScript to hide overlay elements
+                            function hideOverlayElements() {
+                                var iframe = document.querySelector('iframe');
+                                if (iframe && iframe.contentDocument) {
+                                    var style = iframe.contentDocument.createElement('style');
+                                    style.textContent = `
+                                        .ytp-title, .ytp-chrome-top, .ytp-show-cards-title,
+                                        .ytp-title-text, .ytp-title-link, .ytp-title-expanded-overlay,
+                                        .ytp-gradient-top, .ytp-videowall-still, .ytp-ce-element,
+                                        .ytp-cards-teaser, .iv-branding, .ytp-pause-overlay {
+                                            display: none !important;
+                                            visibility: hidden !important;
+                                            opacity: 0 !important;
+                                        }
+                                    `;
+                                    iframe.contentDocument.head.appendChild(style);
+                                }
+                            }
+                            setTimeout(hideOverlayElements, 1000);
+                            setInterval(hideOverlayElements, 2000);
+                            ''' : ''}
+                        },
                         onStateChange: function(event) { sendPlayerStateChange(event.data); },
                         onPlaybackQualityChange: function(event) { window.flutter_inappwebview.callHandler('PlaybackQualityChange', event.data); },
                         onPlaybackRateChange: function(event) { window.flutter_inappwebview.callHandler('PlaybackRateChange', event.data); },

--- a/packages/youtube_player_flutter/lib/src/utils/youtube_player_flags.dart
+++ b/packages/youtube_player_flutter/lib/src/utils/youtube_player_flags.dart
@@ -79,6 +79,11 @@ class YoutubePlayerFlags {
   /// Default is true.
   final bool showLiveFullscreenButton;
 
+  /// Hides the native YouTube overlay (title bar with video info) when set to true.
+  ///
+  /// Default is false.
+  final bool hideYoutubeOverlay;
+
   /// Creates [YoutubePlayerFlags].
   const YoutubePlayerFlags({
     this.hideControls = false,
@@ -96,6 +101,7 @@ class YoutubePlayerFlags {
     this.endAt,
     this.useHybridComposition = true,
     this.showLiveFullscreenButton = true,
+    this.hideYoutubeOverlay = false,
   });
 
   /// Copies new values assigned to the [YoutubePlayerFlags].
@@ -116,6 +122,7 @@ class YoutubePlayerFlags {
     bool? controlsVisibleAtStart,
     bool? useHybridComposition,
     bool? showLiveFullscreenButton,
+    bool? hideYoutubeOverlay,
   }) {
     return YoutubePlayerFlags(
       autoPlay: autoPlay ?? this.autoPlay,
@@ -135,6 +142,7 @@ class YoutubePlayerFlags {
       useHybridComposition: useHybridComposition ?? this.useHybridComposition,
       showLiveFullscreenButton:
           showLiveFullscreenButton ?? this.showLiveFullscreenButton,
+      hideYoutubeOverlay: hideYoutubeOverlay ?? this.hideYoutubeOverlay,
     );
   }
 }


### PR DESCRIPTION
# Add hideYoutubeOverlay flag to hide native YouTube overlay

## Description
Added a new flag `hideYoutubeOverlay` to `YoutubePlayerFlags` that allows hiding the native YouTube overlay (title bar with video info, channel name, and menu dots) when the video is paused or when user interacts with the player.

## Changes Made
- **Added new flag**: `hideYoutubeOverlay` in `YoutubePlayerFlags` class with default value `false`
- **Updated CSS injection**: Added CSS rules to hide YouTube overlay elements when flag is enabled  
- **Enhanced JavaScript**: Added dynamic overlay hiding functionality to handle YouTube's dynamic content loading
- **Updated constructor & copyWith**: Included the new flag in all necessary methods

## Usage
```dart
YoutubePlayer(
  controller: YoutubePlayerController(
    initialVideoId: "video_id", 
    flags: YoutubePlayerFlags(
      hideYoutubeOverlay: true, // Hides YouTube overlay
      // ... other flags
    ),
  ),
)
```

## Benefits
- ✅ Provides cleaner video viewing experience
- ✅ Removes YouTube branding overlay when needed  
- ✅ Backward compatible (default: false)
- ✅ Works with both pause and interaction states