### PR TITLE
Fix duplicate progress indicator in youtube_player_flutter by passing bufferIndicator to PlayPauseButton

### DIFF
--- a/packages/youtube_player_flutter/lib/src/player/youtube_player.dart
+++ b/packages/youtube_player_flutter/lib/src/player/youtube_player.dart
@@ -395,7 +395,11 @@ class _YoutubePlayerState extends State<YoutubePlayer> {
             ),
           ],
           if (!controller.flags.hideControls)
-            const Center(child: PlayPauseButton()),
+            Center(
+              child: PlayPauseButton(
+                bufferIndicator: widget.bufferIndicator,
+              ),
+            ),
           if (controller.value.hasError) errorWidget,
         ],
       ),


### PR DESCRIPTION
The player UI was displaying two progress indicators  one within the PlayPauseButton widget and another outside of it causing a cluttered interface.
This change passes the bufferIndicator widget down to the PlayPauseButton so that the progress indicator is rendered only once in the correct position.

Changes made:

Updated PlayPauseButton to accept and display the bufferIndicator widget.

Removed redundant progress indicator from the main player layout.

Result:
Cleaner UI with a single progress indicator integrated into the PlayPauseButton. This improves visual consistency and reduces unnecessary widget rendering.