### PR TITLE
Update dependencies for go_router, melos, and flutter_lints

### DIFF
--- a/packages/youtube_player_iframe/example/ios/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage/Package.swift
+++ b/packages/youtube_player_iframe/example/ios/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage/Package.swift
@@ -9,22 +9,17 @@ import PackageDescription
 let package = Package(
     name: "FlutterGeneratedPluginSwiftPackage",
     platforms: [
-        .iOS("12.0")
+        .iOS("13.0")
     ],
     products: [
         .library(name: "FlutterGeneratedPluginSwiftPackage", type: .static, targets: ["FlutterGeneratedPluginSwiftPackage"])
     ],
     dependencies: [
-        .package(name: "url_launcher_ios", path: "/Users/sarbagya/.pub-cache/hosted/pub.dev/url_launcher_ios-6.3.1/ios/url_launcher_ios"),
-        .package(name: "webview_flutter_wkwebview", path: "/Users/sarbagya/.pub-cache/hosted/pub.dev/webview_flutter_wkwebview-3.23.0/darwin/webview_flutter_wkwebview")
+        
     ],
     targets: [
         .target(
-            name: "FlutterGeneratedPluginSwiftPackage",
-            dependencies: [
-                .product(name: "url-launcher-ios", package: "url_launcher_ios"),
-                .product(name: "webview-flutter-wkwebview", package: "webview_flutter_wkwebview")
-            ]
+            name: "FlutterGeneratedPluginSwiftPackage"
         )
     ]
 )

--- a/packages/youtube_player_iframe/example/pubspec.yaml
+++ b/packages/youtube_player_iframe/example/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   flutter_web_plugins:
       sdk: flutter
   youtube_player_iframe: ^5.2.0
-  go_router: ^14.6.0
+  go_router: ^16.2.4
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,5 +4,5 @@ environment:
   sdk: '>=3.0.0 <4.0.0'
 
 dev_dependencies:
-  melos: ^3.4.0
-  flutter_lints: ^3.0.1
+  melos: ^7.1.1
+  flutter_lints: ^6.0.0


### PR DESCRIPTION
Upgrade the go_router dependency to version 16.2.4 and update dev_dependencies for melos and flutter_lints to their latest versions. Adjust the iOS platform version requirement to 13.0.