### PR TITLE
fix: sends origin as separate parameters and dashed videoId

### DIFF
--- a/packages/youtube_player_iframe/assets/player.html
+++ b/packages/youtube_player_iframe/assets/player.html
@@ -46,11 +46,11 @@
 
       var platform = "<<platform>>";
       var host = "<<host>>";
+      var videoId = "<<videoId>>";
       var player;
       var timerId;
 
-      function onYouTubeIframeAPIReady() {
-        player = new YT.Player("<<playerId>>", {
+      var playerConfig = {
           host: host,
           playerVars: <<playerVars>>,
           events: {
@@ -87,8 +87,15 @@
             onAutoplayBlocked: function (event) {
               sendMessage('AutoplayBlocked', event.data);
             },
-          },
-        });
+          }
+      };
+
+      if(videoId) {
+          playerConfig['videoId'] = videoId;
+        }
+
+      function onYouTubeIframeAPIReady() {
+        player = new YT.Player("<<playerId>>", playerConfig);
         player.setSize(window.innerWidth, window.innerHeight);
       }
 

--- a/packages/youtube_player_iframe/example/pubspec.yaml
+++ b/packages/youtube_player_iframe/example/pubspec.yaml
@@ -11,7 +11,8 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
       sdk: flutter
-  youtube_player_iframe: ^5.2.0
+  youtube_player_iframe: 
+    path: ../
   go_router: ^14.6.0
 
 dev_dependencies:

--- a/packages/youtube_player_iframe/lib/src/controller/youtube_player_controller.dart
+++ b/packages/youtube_player_iframe/lib/src/controller/youtube_player_controller.dart
@@ -22,9 +22,12 @@ typedef YoutubeWebResourceError = WebResourceError;
 ///
 /// After [YoutubePlayerController.close] all further calls are ignored.
 class YoutubePlayerController implements YoutubePlayerIFrameAPI {
+  final String? initialVideoId;
+
   /// Creates [YoutubePlayerController].
   YoutubePlayerController({
     this.params = const YoutubePlayerParams(),
+    this.initialVideoId,
     ValueChanged<YoutubeWebResourceError>? onWebResourceError,
     this.key,
   }) {
@@ -77,7 +80,8 @@ class YoutubePlayerController implements YoutubePlayerIFrameAPI {
     double? startSeconds,
     double? endSeconds,
   }) {
-    final controller = YoutubePlayerController(params: params, key: videoId);
+    final controller = YoutubePlayerController(
+        params: params, key: videoId, initialVideoId: videoId);
 
     if (autoPlay) {
       controller.loadVideoById(
@@ -270,7 +274,8 @@ class YoutubePlayerController implements YoutubePlayerIFrameAPI {
       'pointerEvents': params.pointerEvents.name,
       'playerVars': params.toJson(),
       'platform': platform,
-      'host': params.origin ?? 'https://www.youtube.com',
+      'host': params.host ?? 'https://www.youtube.com',
+      'videoId': initialVideoId ?? '',
     };
 
     await webViewController.loadHtmlString(
@@ -327,7 +332,8 @@ class YoutubePlayerController implements YoutubePlayerIFrameAPI {
 
   /// The unique player id.
   @internal
-  String get playerId => 'Youtube${key ?? hashCode}';
+  String get playerId =>
+      'Youtube${initialVideoId ?? key ?? hashCode}'.replaceAll('-', '/-');
 
   /// MetaData for the currently loaded or cued video.
   YoutubeMetaData get metadata => _value.metaData;

--- a/packages/youtube_player_iframe/lib/src/controller/youtube_player_controller.dart
+++ b/packages/youtube_player_iframe/lib/src/controller/youtube_player_controller.dart
@@ -332,8 +332,7 @@ class YoutubePlayerController implements YoutubePlayerIFrameAPI {
 
   /// The unique player id.
   @internal
-  String get playerId =>
-      'Youtube${initialVideoId ?? key ?? hashCode}'.replaceAll('-', '/-');
+  String get playerId => 'Youtube${initialVideoId ?? key ?? hashCode}';
 
   /// MetaData for the currently loaded or cued video.
   YoutubeMetaData get metadata => _value.metaData;

--- a/packages/youtube_player_iframe/lib/src/player_params.dart
+++ b/packages/youtube_player_iframe/lib/src/player_params.dart
@@ -96,6 +96,7 @@ class YoutubePlayerParams {
   ///
   /// Specify your domain as the value.
   final String? origin;
+  final String? host;
 
   /// This parameter controls whether videos play inline or fullscreen in an HTML5 player on iOS.
   ///
@@ -125,6 +126,7 @@ class YoutubePlayerParams {
     this.showVideoAnnotations = true,
     this.loop = false,
     this.origin = 'https://www.youtube.com',
+    this.host = 'https://www.youtube.com',
     this.playsInline = true,
     this.strictRelatedVideos = false,
     this.userAgent,

--- a/packages/youtube_player_iframe/pubspec.yaml
+++ b/packages/youtube_player_iframe/pubspec.yaml
@@ -1,6 +1,6 @@
 name: youtube_player_iframe
 description: Flutter port of the official YouTube iFrame player API. Supports web & mobile platforms.
-version: 5.2.2
+version: 5.3.0
 repository: https://github.com/sarbagyastha/youtube_player_flutter
 homepage: https://github.com/sarbagyastha/youtube_player_flutter/tree/main/packages/youtube_player_iframe
 

--- a/packages/youtube_player_iframe/pubspec.yaml
+++ b/packages/youtube_player_iframe/pubspec.yaml
@@ -1,6 +1,6 @@
 name: youtube_player_iframe
 description: Flutter port of the official YouTube iFrame player API. Supports web & mobile platforms.
-version: 5.3.0
+version: 5.2.2
 repository: https://github.com/sarbagyastha/youtube_player_flutter
 homepage: https://github.com/sarbagyastha/youtube_player_flutter/tree/main/packages/youtube_player_iframe
 


### PR DESCRIPTION
Closes #1125:

Analyzing the correction of this same error [in the native Android library](https://github.com/PierfrancescoSoffritti/android-youtube-player/issues/1252#issuecomment-3315089833), I noticed that when passing the origin and host fields as separate parameters, the error code 15 no longer occurs.

```dart
YoutubePlayerController.fromVideoId(
      videoId: widget.videoId,
      params: YoutubePlayerParams(
        origin: Uri.https(
          '${packageName}',
        ).toString(),
      ),
    )
```

Update (2025-11-05):
This solution is confirmed by [this documentation](https://developers.google.com/youtube/terms/required-minimum-functionality?#referer-format)