### PR TITLE
fix: videoId with dashes broken on start

### DIFF
--- a/packages/youtube_player_iframe/lib/src/controller/youtube_player_controller.dart
+++ b/packages/youtube_player_iframe/lib/src/controller/youtube_player_controller.dart
@@ -327,7 +327,7 @@ class YoutubePlayerController implements YoutubePlayerIFrameAPI {
 
   /// The unique player id.
   @internal
-  String get playerId => 'Youtube${key ?? hashCode}';
+  String get playerId => 'Youtube${key ?? hashCode}'.replaceAll('-', '_');
 
   /// MetaData for the currently loaded or cued video.
   YoutubeMetaData get metadata => _value.metaData;


### PR DESCRIPTION
Closes #1121 
When the video contains hyphen in its videoId, it will not start automatically because a parse issue. So I just replaced the character and it will works correctly. You can testing using this video:

```dart
YoutubePlayerController.fromVideoId(
      videoId: 'aqz-KE-bpKQ',
      autoPlay: true,
```