### PR TITLE
[BUG WEB] - When multiple players share the same playerId on the web, only one was loading.

### DIFF
--- a/packages/youtube_player_iframe/assets/player.html
+++ b/packages/youtube_player_iframe/assets/player.html
@@ -133,6 +133,7 @@
          var message = {};
          message[key] = data;
          message['playerId'] = '<<playerId>>';
+         message['youtubePlayerMessageChannelKey'] = '<<youtubePlayerMessageChannelKey>>';
          var messageString = JSON.stringify(message);
 
          sendPlatformMessage(messageString);

--- a/packages/youtube_player_iframe/lib/src/controller/youtube_player_controller.dart
+++ b/packages/youtube_player_iframe/lib/src/controller/youtube_player_controller.dart
@@ -27,6 +27,7 @@ class YoutubePlayerController implements YoutubePlayerIFrameAPI {
     this.params = const YoutubePlayerParams(),
     ValueChanged<YoutubeWebResourceError>? onWebResourceError,
     this.key,
+    this.youtubePlayerMessageChannelKey,
   }) {
     _eventHandler = YoutubePlayerEventHandler(this);
 
@@ -76,8 +77,9 @@ class YoutubePlayerController implements YoutubePlayerIFrameAPI {
     bool autoPlay = false,
     double? startSeconds,
     double? endSeconds,
+    String? youtubePlayerMessageChannelKey,
   }) {
-    final controller = YoutubePlayerController(params: params, key: videoId);
+    final controller = YoutubePlayerController(params: params, key: videoId, youtubePlayerMessageChannelKey: youtubePlayerMessageChannelKey);
 
     if (autoPlay) {
       controller.loadVideoById(
@@ -98,6 +100,9 @@ class YoutubePlayerController implements YoutubePlayerIFrameAPI {
 
   /// The unique key for the player.
   final String? key;
+
+  /// The key for the message channel of the player web view.
+  final String? youtubePlayerMessageChannelKey;
 
   /// Defines player parameters for the youtube player.
   final YoutubePlayerParams params;
@@ -271,6 +276,7 @@ class YoutubePlayerController implements YoutubePlayerIFrameAPI {
       'playerVars': params.toJson(),
       'platform': platform,
       'host': params.origin ?? 'https://www.youtube.com',
+      'youtubePlayerMessageChannelKey': youtubePlayerMessageChannelKey ?? '',
     };
 
     await webViewController.loadHtmlString(

--- a/packages/youtube_player_iframe/lib/src/controller/youtube_player_event_handler.dart
+++ b/packages/youtube_player_iframe/lib/src/controller/youtube_player_event_handler.dart
@@ -35,7 +35,11 @@ class YoutubePlayerEventHandler {
   /// Handles the [javaScriptMessage] from the player iframe and create events.
   void call(JavaScriptMessage javaScriptMessage) {
     final data = Map.from(jsonDecode(javaScriptMessage.message));
-    if (data['playerId'] != controller.playerId) return;
+    if(data["youtubePlayerMessageChannelKey"]== null || data["youtubePlayerMessageChannelKey"] == ""){
+      if (data['playerId'] != controller.playerId) return;
+    } else {
+      if (data['youtubePlayerMessageChannelKey'] != controller.youtubePlayerMessageChannelKey) return;
+    }
 
     for (final entry in data.entries) {
       if (entry.key == 'ApiChange') {


### PR DESCRIPTION
Fix: Added an external key to handle cases where the same video appears multiple times on the same page, which was causing the iframe player on web to fail loading.

Add youtubePlayerMessageChannelKey to player communication

- Introduced youtubePlayerMessageChannelKey in player.html and YoutubePlayerController to enhance message handling.
- Updated event handler to validate the message channel key alongside playerId for improved message integrity.