### PR TITLE
Add autoPlay to YoutubePlayerParams

### DIFF
--- a/packages/youtube_player_iframe/lib/src/player_params.dart
+++ b/packages/youtube_player_iframe/lib/src/player_params.dart
@@ -9,6 +9,9 @@ import 'package:youtube_player_iframe/youtube_player_iframe.dart';
 
 /// Defines player parameters for [YoutubePlayer].
 class YoutubePlayerParams {
+  // Specify whether the initial video will automatically start to play when the player loads.
+  final bool autoPlay;
+
   /// Mutes the player.
   ///
   /// Default is false.
@@ -112,6 +115,7 @@ class YoutubePlayerParams {
 
   /// Defines player parameters for the youtube player.
   const YoutubePlayerParams({
+    this.autoPlay = true,
     this.mute = false,
     this.captionLanguage = 'en',
     this.enableCaption = true,
@@ -133,7 +137,7 @@ class YoutubePlayerParams {
   /// Creates [Map] representation of [YoutubePlayerParams].
   Map<String, dynamic> toMap() {
     return {
-      'autoplay': 1,
+      'autoplay': _boolean(autoPlay),
       'mute': _boolean(mute),
       'cc_lang_pref': captionLanguage,
       'cc_load_policy': _boolean(enableCaption),


### PR DESCRIPTION
This PR adds `autoPlay` to `YoutubePlayerParams`, in order to prevent autoplay when using the fix in [#1126](https://github.com/sarbagyastha/youtube_player_flutter/pull/1126).

When I applied the fix in [#1126](https://github.com/sarbagyastha/youtube_player_flutter/pull/1126), youtube videos started autoplaying, although previously they did not autoplay. Setting the player parameter `autoplay` was needed to prevent autoplay. 

Note: it's possible that the behavior changed because the fix [#1126](https://github.com/sarbagyastha/youtube_player_flutter/pull/1126) requires `YoutubePlayerController` to have `initialVideoId` set. Using `YoutubePlayerController` without `initialVideoId` used to work fine, but now I get an error if I don't set `initialVideoId`.

**Example:**

Code that used to work to cue a video (no autoplay):

```
_controller = YoutubePlayerController(
  params: YoutubePlayerParams(),
  key: widget.videoId,
);
_controller.cueVideoById(videoId: widget.videoId);
```

Code that works to cue a video (no autoplay), when using the fix in [#1126](https://github.com/sarbagyastha/youtube_player_flutter/pull/1126):

```
_controller = YoutubePlayerController(
  initialVideoId: widget.videoId,
  params: YoutubePlayerParams(
    autoPlay: false,
    origin: Uri.https('${packageName}').toString(),
  ),
  key: widget.videoId,
);
_controller.cueVideoById(videoId: widget.videoId);
```
