### PR TITLE
Add support for forcing the original audio track via YoutubePlayerFlags

### DIFF
--- a/packages/youtube_player_flutter/lib/src/player/raw_youtube_player.dart
+++ b/packages/youtube_player_flutter/lib/src/player/raw_youtube_player.dart
@@ -205,12 +205,17 @@ class _RawYoutubePlayerState extends State<RawYoutubePlayer>
             ..addJavaScriptHandler(
               handlerName: 'VideoTime',
               callback: (args) {
-                final position = args.first * 1000;
-                final num buffered = args.last;
+                final num positionNum = (args.isNotEmpty && args.first != null)
+                    ? args.first as num
+                    : 0;
+                final num bufferedNum = (args.isNotEmpty && args.last != null)
+                    ? args.last as num
+                    : 0;
                 controller!.updateValue(
                   controller!.value.copyWith(
-                    position: Duration(milliseconds: position.floor()),
-                    buffered: buffered.toDouble(),
+                    position:
+                        Duration(milliseconds: (positionNum * 1000).floor()),
+                    buffered: bufferedNum.toDouble(),
                   ),
                 );
               },

--- a/packages/youtube_player_flutter/lib/src/player/raw_youtube_player.dart
+++ b/packages/youtube_player_flutter/lib/src/player/raw_youtube_player.dart
@@ -274,7 +274,12 @@ class _RawYoutubePlayerState extends State<RawYoutubePlayer>
                         'cc_lang_pref': '${controller!.flags.captionLanguage}',
                         'autoplay': ${boolean(value: controller!.flags.autoPlay)},
                         'start': ${controller!.flags.startAt},
-                        'end': ${controller!.flags.endAt}
+                        'end': ${controller!.flags.endAt},
+                        ${controller!.flags.forceOriginalAudio ? "'hl': '${controller!.flags.originalAudioLanguage}'," : ""}
+                        ${controller!.flags.forceOriginalAudio ? "'lang': '${controller!.flags.originalAudioLanguage}'," : ""}
+                        ${controller!.flags.forceOriginalAudio ? "'audio_lang': '${controller!.flags.originalAudioLanguage}'," : ""}
+                        ${controller!.flags.forceOriginalAudio ? "'original': 1," : ""}
+                        ${controller!.flags.forceOriginalAudio ? "'acont': '${controller!.flags.originalAudioLanguage}'" : ""}
                     },
                     events: {
                         onReady: function(event) { window.flutter_inappwebview.callHandler('Ready'); },

--- a/packages/youtube_player_flutter/lib/src/player/raw_youtube_player.dart
+++ b/packages/youtube_player_flutter/lib/src/player/raw_youtube_player.dart
@@ -280,12 +280,15 @@ class _RawYoutubePlayerState extends State<RawYoutubePlayer>
                         'autoplay': ${boolean(value: controller!.flags.autoPlay)},
                         'start': ${controller!.flags.startAt},
                         'end': ${controller!.flags.endAt},
-                        ${controller!.flags.forceOriginalAudio ? "'hl': '${controller!.flags.originalAudioLanguage}'," : ""}
-                        ${controller!.flags.forceOriginalAudio ? "'lang': '${controller!.flags.originalAudioLanguage}'," : ""}
-                        ${controller!.flags.forceOriginalAudio ? "'audio_lang': '${controller!.flags.originalAudioLanguage}'," : ""}
-                        ${controller!.flags.forceOriginalAudio ? "'original': 1," : ""}
-                        ${controller!.flags.forceOriginalAudio ? "'acont': '${controller!.flags.originalAudioLanguage}'" : ""}
-                    },
+                        ${controller!.flags.audioLanguage == null
+                          ? "'original': 1,"
+                          : """
+                            'hl': '${controller!.flags.audioLanguage}',
+                            'lang': '${controller!.flags.audioLanguage}',
+                            'audio_lang': '${controller!.flags.audioLanguage}',
+                            """
+                        }
+                      },
                     events: {
                         onReady: function(event) { window.flutter_inappwebview.callHandler('Ready'); },
                         onStateChange: function(event) { sendPlayerStateChange(event.data); },

--- a/packages/youtube_player_flutter/lib/src/utils/youtube_player_flags.dart
+++ b/packages/youtube_player_flutter/lib/src/utils/youtube_player_flags.dart
@@ -79,6 +79,16 @@ class YoutubePlayerFlags {
   /// Default is true.
   final bool showLiveFullscreenButton;
 
+  /// Defines whether to use the original audio track or not (forces the original audio track to be used).
+  ///
+  /// Default is false.
+  final bool forceOriginalAudio;
+
+  /// Specifies the default language that the player will use to display the original audio track. Set the parameter's value to an [ISO 639-1 two-letter language code](http://www.loc.gov/standards/iso639-2/php/code_list.php).
+  ///
+  /// Default is `ar`.
+  final String originalAudioLanguage;
+
   /// Creates [YoutubePlayerFlags].
   const YoutubePlayerFlags({
     this.hideControls = false,
@@ -96,6 +106,8 @@ class YoutubePlayerFlags {
     this.endAt,
     this.useHybridComposition = true,
     this.showLiveFullscreenButton = true,
+    this.forceOriginalAudio = false,
+    this.originalAudioLanguage = 'ar',
   });
 
   /// Copies new values assigned to the [YoutubePlayerFlags].
@@ -116,6 +128,8 @@ class YoutubePlayerFlags {
     bool? controlsVisibleAtStart,
     bool? useHybridComposition,
     bool? showLiveFullscreenButton,
+    bool? forceOriginalAudio,
+    String? originalAudioLanguage,
   }) {
     return YoutubePlayerFlags(
       autoPlay: autoPlay ?? this.autoPlay,
@@ -135,6 +149,8 @@ class YoutubePlayerFlags {
       useHybridComposition: useHybridComposition ?? this.useHybridComposition,
       showLiveFullscreenButton:
           showLiveFullscreenButton ?? this.showLiveFullscreenButton,
+      forceOriginalAudio: forceOriginalAudio ?? this.forceOriginalAudio,
+      originalAudioLanguage: originalAudioLanguage ?? this.originalAudioLanguage,
     );
   }
 }

--- a/packages/youtube_player_flutter/lib/src/utils/youtube_player_flags.dart
+++ b/packages/youtube_player_flutter/lib/src/utils/youtube_player_flags.dart
@@ -79,15 +79,11 @@ class YoutubePlayerFlags {
   /// Default is true.
   final bool showLiveFullscreenButton;
 
-  /// Defines whether to use the original audio track or not (forces the original audio track to be used).
-  ///
-  /// Default is false.
-  final bool forceOriginalAudio;
 
-  /// Specifies the default language that the player will use to display the original audio track. Set the parameter's value to an [ISO 639-1 two-letter language code](http://www.loc.gov/standards/iso639-2/php/code_list.php).
-  ///
-  /// Default is `ar`.
-  final String originalAudioLanguage;
+  /// Preferred audio language for the video.
+  /// If null, the player will use the original audio track.
+  /// Uses ISO 639-1 language codes (e.g. 'en', 'ar').
+  final String? audioLanguage;
 
   /// Creates [YoutubePlayerFlags].
   const YoutubePlayerFlags({
@@ -106,8 +102,7 @@ class YoutubePlayerFlags {
     this.endAt,
     this.useHybridComposition = true,
     this.showLiveFullscreenButton = true,
-    this.forceOriginalAudio = false,
-    this.originalAudioLanguage = 'ar',
+    this.audioLanguage,
   });
 
   /// Copies new values assigned to the [YoutubePlayerFlags].
@@ -128,8 +123,7 @@ class YoutubePlayerFlags {
     bool? controlsVisibleAtStart,
     bool? useHybridComposition,
     bool? showLiveFullscreenButton,
-    bool? forceOriginalAudio,
-    String? originalAudioLanguage,
+    String? audioLanguage,
   }) {
     return YoutubePlayerFlags(
       autoPlay: autoPlay ?? this.autoPlay,
@@ -149,8 +143,7 @@ class YoutubePlayerFlags {
       useHybridComposition: useHybridComposition ?? this.useHybridComposition,
       showLiveFullscreenButton:
           showLiveFullscreenButton ?? this.showLiveFullscreenButton,
-      forceOriginalAudio: forceOriginalAudio ?? this.forceOriginalAudio,
-      originalAudioLanguage: originalAudioLanguage ?? this.originalAudioLanguage,
+      audioLanguage: audioLanguage ?? this.audioLanguage,
     );
   }
 }


### PR DESCRIPTION
## Overview
This PR adds support for selecting the **original or preferred audio track** in the YouTube player by introducing a single, simplified `audioLanguage` flag in `YoutubePlayerFlags`.
It also includes a small fix to safely handle null or missing video position and buffer values in `_RawYoutubePlayerState`.

---

## Key Changes

### 1. Audio Track Selection Support
**New flag added in `youtube_player_flags.dart`:**

```dart
/// Preferred audio language for the video.
/// If null, the player will use the original audio track.
/// Set the value to an ISO 639-1 two-letter language code (e.g. 'en', 'ar').
final String? audioLanguage;
```

**Integrated into `_RawYoutubePlayerState` configuration (`raw_youtube_player.dart`):**

```dart
'end': \${controller!.flags.endAt},
\${controller!.flags.audioLanguage == null
  ? "'original': 1,"
  : "'hl': '\${controller!.flags.audioLanguage}',\n     'lang': '\${controller!.flags.audioLanguage}',\n     'audio_lang': '\${controller!.flags.audioLanguage}',"
}
```

**Behavior:**
- `audioLanguage == null` → forces the **original audio track**
- `audioLanguage != null` → plays the **preferred alternative audio track**

---

### 2. Fixed Null Handling in Position & Buffer Values
Improved reliability by preventing potential null or empty array errors from the JS handler:

```dart
final num positionNum = (args.isNotEmpty && args.first != null)
    ? args.first as num
    : 0;
final num bufferedNum = (args.isNotEmpty && args.last != null)
    ? args.last as num
    : 0;

controller!.updateValue(
  controller!.value.copyWith(
    position: Duration(milliseconds: (positionNum * 1000).floor()),
    buffered: bufferedNum.toDouble(),
  ),
);
```

---

## Testing
- Verified with:
  - `audioLanguage: null` → original audio track is used
  - `audioLanguage: 'ar'` → preferred audio language is applied
- Confirmed that video progress and buffer updates remain stable even when JS arguments are missing or null.

---

## Why This Matters
YouTube videos often include dubbed or alternative audio tracks that override the original sound.
This change gives developers explicit and intuitive control over audio track selection, which is essential for educational, media, and localization-sensitive applications.
