### PR TITLE
fix: sanitize video ID dashes in playerId to prevent JS identifier errors

### DIFF
--- a/packages/youtube_player_iframe/lib/src/controller/youtube_player_controller.dart
+++ b/packages/youtube_player_iframe/lib/src/controller/youtube_player_controller.dart
@@ -327,7 +327,8 @@ class YoutubePlayerController implements YoutubePlayerIFrameAPI {
 
   /// The unique player id.
   @internal
-  String get playerId => 'Youtube${key ?? hashCode}';
+  String get playerId =>
+      'Youtube${(key ?? hashCode.toString()).replaceAll('-', '_')}';
 
   /// MetaData for the currently loaded or cued video.
   YoutubeMetaData get metadata => _value.metaData;


### PR DESCRIPTION
## Summary

- YouTube video IDs can contain dashes (e.g. `Jl1-bmN1b8o`), which are invalid in JavaScript identifiers
- The generated `playerId` (e.g. `YoutubeJl1-bmN1b8o`) was being parsed as a subtraction expression in JS, causing a `ReferenceError` and failed video playback
- Fixed by replacing dashes with underscores in `playerId` so the result is always a valid JS identifier

## Root Cause

```dart
// Before (broken with dash-containing IDs)
String get playerId => 'Youtube${key ?? hashCode}';

// After (safe for all valid YouTube IDs)
String get playerId =>
    'Youtube${(key ?? hashCode.toString()).replaceAll('-', '_')}';
```

## Test plan

- [ ] Load a video with a dash in its ID (e.g. `Jl1-bmN1b8o`)
- [ ] Verify the video plays successfully without JS errors
- [ ] Verify videos without dashes continue to work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)